### PR TITLE
Add svn_cat and svn_list tools and translate project to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,40 @@
 # SVN MCP Server
 
-Un servidor MCP (Model Context Protocol) completo para integración con Subversion (SVN), diseñado para permitir a agentes de IA gestionar repositorios SVN de manera eficiente.
+A complete MCP (Model Context Protocol) server for Subversion (SVN) integration, designed to let AI agents manage SVN repositories efficiently.
 
-## 🎯 Características
+## 🎯 Features
 
-- ✅ **Operaciones básicas de repositorio**: info, status, log, diff, checkout, update
-- ✅ **Gestión de archivos**: add, commit, delete, revert
-- ✅ **Herramientas de mantenimiento**: cleanup
-- 🔄 **Gestión de ramas**: (En desarrollo)
-- 🔄 **Operaciones avanzadas**: merge, switch, properties (En desarrollo)
-- 🔄 **Herramientas de análisis**: blame, conflict detection (En desarrollo)
-- 🔄 **Operaciones en lote**: (En desarrollo)
+- ✅ **Basic repository operations**: info, status, log, diff, checkout, update
+- ✅ **File management**: add, commit, delete, revert
+- ✅ **Maintenance tools**: cleanup
+- 🔄 **Branch management**: (In development)
+- 🔄 **Advanced operations**: merge, switch, properties (In development)
+- 🔄 **Analysis tools**: blame, conflict detection (In development)
+- 🔄 **Batch operations**: (In development)
 
-## 📋 Requisitos
+## 📋 Requirements
 
 - **Node.js** >= 18.0.0
-- **Subversion (SVN)** instalado y disponible en PATH
-- **TypeScript** (para desarrollo)
+- **Subversion (SVN)** installed and available on PATH
+- **TypeScript** (for development)
 
-### 🔍 Detectar instalación de SVN
+### 🔍 Detecting the SVN installation
 
-#### Verificar si SVN está instalado
+#### Check whether SVN is installed
 
 ```bash
-# Comando básico para verificar SVN
+# Basic command to check SVN
 svn --version
 
-# Verificar ruta completa del ejecutable
+# Check the full path of the executable
 where svn        # Windows
 which svn        # Linux/Mac
 
-# Verificar cliente SVN completo
+# Check the full SVN client
 svn --version --verbose
 ```
 
-#### Salida esperada si SVN está correctamente instalado:
+#### Expected output if SVN is correctly installed:
 
 ```
 svn, version 1.14.x (r1876290)
@@ -46,82 +46,82 @@ see the NOTICE file for more information.
 Subversion is open source software, see http://subversion.apache.org/
 ```
 
-#### ❌ Errores comunes si SVN NO está instalado:
+#### ❌ Common errors if SVN is NOT installed:
 
 ```bash
 # Windows
 'svn' is not recognized as an internal or external command
 
-# Linux/Mac  
+# Linux/Mac
 svn: command not found
 bash: svn: command not found
 ```
 
-#### 🛠️ Diagnóstico avanzado
+#### 🛠️ Advanced diagnostics
 
 ```bash
-# Verificar PATH del sistema
+# Check the system PATH
 echo $PATH                    # Linux/Mac
 echo %PATH%                   # Windows CMD
 $env:PATH                     # Windows PowerShell
 
-# Buscar executables SVN en el sistema
+# Search for SVN executables on the system
 find / -name "svn" 2>/dev/null           # Linux
 Get-ChildItem -Path C:\ -Name "svn.exe" -Recurse -ErrorAction SilentlyContinue  # Windows PowerShell
 
-# Verificar versión específica del cliente
-svn --version | head -1       # Obtener solo la primera línea con la versión
+# Check the specific client version
+svn --version | head -1       # Get just the first line with the version
 ```
 
-### 💾 Instalar SVN en Windows
+### 💾 Installing SVN on Windows
 
-#### Opción 1: Gestores de paquetes
+#### Option 1: Package managers
 
 ```bash
-# Usando Chocolatey (Recomendado)
+# Using Chocolatey (Recommended)
 choco install subversion
 
-# Usando winget
+# Using winget
 winget install CollabNet.Subversion
 
-# Usando Scoop
+# Using Scoop
 scoop install subversion
 ```
 
-#### Opción 2: Instaladores oficiales
+#### Option 2: Official installers
 
-1. **TortoiseSVN** (incluye cliente de línea de comandos):
+1. **TortoiseSVN** (includes the command-line client):
    ```
    https://tortoisesvn.net/downloads.html
-   ✅ Incluye cliente GUI y CLI
-   ✅ Integración con Windows Explorer
+   ✅ Includes GUI and CLI clients
+   ✅ Windows Explorer integration
    ```
 
-2. **SlikSVN** (solo línea de comandos):
+2. **SlikSVN** (command line only):
    ```
    https://sliksvn.com/download/
-   ✅ Ligero (solo CLI)
-   ✅ Ideal para automatización
+   ✅ Lightweight (CLI only)
+   ✅ Ideal for automation
    ```
 
 3. **CollabNet Subversion**:
    ```
    https://www.collab.net/downloads/subversion
-   ✅ Versión empresarial
-   ✅ Soporte comercial disponible
+   ✅ Enterprise version
+   ✅ Commercial support available
    ```
 
-#### Opción 3: Visual Studio o Git for Windows
+#### Option 3: Visual Studio or Git for Windows
 
 ```bash
-# Si tienes Git for Windows instalado, puede incluir SVN
+# If you have Git for Windows installed, it can include SVN
 git svn --version
 
-# Visual Studio también puede incluir SVN
-# Ir a: Visual Studio Installer > Modify > Individual Components > Subversion
+# Visual Studio can also include SVN
+# Go to: Visual Studio Installer > Modify > Individual Components > Subversion
 ```
 
-### 🐧 Instalar SVN en Linux
+### 🐧 Installing SVN on Linux
 
 ```bash
 # Ubuntu/Debian
@@ -139,55 +139,55 @@ sudo pacman -S subversion
 sudo apk add subversion
 ```
 
-### 🍎 Instalar SVN en macOS
+### 🍎 Installing SVN on macOS
 
 ```bash
-# Homebrew (Recomendado)
+# Homebrew (Recommended)
 brew install subversion
 
 # MacPorts
 sudo port install subversion
 
-# Desde Xcode Command Line Tools (puede estar incluido)
+# From Xcode Command Line Tools (may already be included)
 xcode-select --install
 ```
 
-### 🔧 Configurar SVN después de la instalación
+### 🔧 Configuring SVN after installation
 
-#### Verificar configuración global
+#### Check the global configuration
 
 ```bash
-# Ver configuración actual
+# Show current configuration
 svn config --list
 
-# Configurar usuario global
-svn config --global auth:username tu_usuario
+# Configure the global user
+svn config --global auth:username your_username
 
-# Configurar editor por defecto
+# Configure the default editor
 svn config --global editor "code --wait"     # VS Code
 svn config --global editor "notepad"         # Windows Notepad
 svn config --global editor "nano"            # Linux/Mac nano
 ```
 
-#### Verificar acceso a repositorios
+#### Check repository access
 
 ```bash
-# Probar conexión a repositorio (sin hacer checkout)
-svn list https://svn.ejemplo.com/repo/trunk
+# Test connection to a repository (without checking out)
+svn list https://svn.example.com/repo/trunk
 
-# Probar con credenciales específicas
-svn list https://svn.ejemplo.com/repo/trunk --username usuario --password contraseña
+# Test with specific credentials
+svn list https://svn.example.com/repo/trunk --username user --password password
 ```
 
-## 🚀 Instalación
+## 🚀 Installation
 
-### Desde NPM
+### From NPM
 
 ```bash
 npm install -g @grec0/mcp-svn
 ```
 
-### Desarrollo Local
+### Local Development
 
 ```bash
 git clone https://github.com/gcorroto/mcp-svn.git
@@ -196,19 +196,26 @@ npm install
 npm run build
 ```
 
-## ⚙️ Configuración
+## ⚙️ Configuration
 
-### Variables de Entorno
+### Environment Variables
 
-| Variable | Descripción | Por Defecto |
-|----------|-------------|-------------|
-| `SVN_PATH` | Ruta del ejecutable SVN | `svn` |
-| `SVN_WORKING_DIRECTORY` | Directorio de trabajo | `process.cwd()` |
-| `SVN_USERNAME` | Usuario para autenticación | - |
-| `SVN_PASSWORD` | Contraseña para autenticación | - |
-| `SVN_TIMEOUT` | Timeout en milisegundos | `30000` |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SVN_PATH` | Path to the SVN executable | `svn` |
+| `SVN_WORKING_DIRECTORY` | Local working copy directory | `process.cwd()` |
+| `SVN_URL` (alias: `SVN_REPOSITORY_URL`) | Repository URL. Enables URL-only workflows and `/trunk/...` target resolution | - |
+| `SVN_USERNAME` | Authentication user | - |
+| `SVN_PASSWORD` | Authentication password | - |
+| `SVN_TIMEOUT` | Timeout in milliseconds | `30000` |
 
-### Ejemplo de configuración MCP
+`SVN_WORKING_DIRECTORY` and `SVN_URL` are independent — set either or both. With both configured, local operations (`svn_status`, `svn_commit`, ...) run in the working copy, and URL-capable tools (`svn_cat`, `svn_list`, `svn_info`, `svn_log`, `svn_diff`) can be called with:
+
+- a full URL (`https://svn.example.com/repo/trunk/file.sql`)
+- a repo-relative path starting with `/` (`/trunk/file.sql`) — joined with `SVN_URL`
+- a local path — resolved against the working copy
+
+### Example MCP Configuration
 
 ```json
 {
@@ -218,58 +225,59 @@ npm run build
       "args": ["@grec0/mcp-svn"],
       "env": {
         "SVN_PATH": "svn",
-        "SVN_WORKING_DIRECTORY": "/path/to/working/copy",
-        "SVN_USERNAME": "tu_usuario",
-        "SVN_PASSWORD": "tu_contraseña"
+        "SVN_WORKING_DIRECTORY": "C:/path/to/working/copy",
+        "SVN_URL": "https://svn.example.com/repo",
+        "SVN_USERNAME": "your_username",
+        "SVN_PASSWORD": "your_password"
       }
     }
   }
 }
 ```
 
-## 🛠️ Herramientas Disponibles
+## 🛠️ Available Tools
 
-### Operaciones Básicas
+### Basic Operations
 
 #### `svn_health_check`
-Verificar el estado de salud del sistema SVN y working copy.
+Check the health status of the SVN system and working copy.
 
 ```
 svn_health_check()
 ```
 
 #### `svn_info`
-Obtener información detallada del working copy o archivo específico.
+Get detailed information about the working copy or a specific file.
 
 ```
 svn_info(path?: string)
 ```
 
-#### `svn_status` 
-Ver el estado de archivos en el working copy.
+#### `svn_status`
+Show the status of files in the working copy.
 
 ```
 svn_status(path?: string, showAll?: boolean)
 ```
 
 #### `svn_log`
-Ver historial de commits del repositorio.
+Show the commit history of the repository.
 
 ```
 svn_log(path?: string, limit?: number, revision?: string)
 ```
 
 #### `svn_diff`
-Ver diferencias entre versiones de archivos.
+Show differences between file revisions.
 
 ```
 svn_diff(path?: string, oldRevision?: string, newRevision?: string)
 ```
 
-### Operaciones de Repositorio
+### Repository Operations
 
 #### `svn_checkout`
-Hacer checkout de un repositorio SVN.
+Check out an SVN repository.
 
 ```
 svn_checkout(
@@ -283,7 +291,7 @@ svn_checkout(
 ```
 
 #### `svn_update`
-Actualizar working copy desde el repositorio.
+Update the working copy from the repository.
 
 ```
 svn_update(
@@ -295,10 +303,10 @@ svn_update(
 )
 ```
 
-### Gestión de Archivos
+### File Management
 
 #### `svn_add`
-Añadir archivos al control de versiones.
+Add files to version control.
 
 ```
 svn_add(
@@ -312,7 +320,7 @@ svn_add(
 ```
 
 #### `svn_commit`
-Confirmar cambios al repositorio.
+Commit changes to the repository.
 
 ```
 svn_commit(
@@ -326,7 +334,7 @@ svn_commit(
 ```
 
 #### `svn_delete`
-Eliminar archivos del control de versiones.
+Remove files from version control.
 
 ```
 svn_delete(
@@ -338,51 +346,51 @@ svn_delete(
 ```
 
 #### `svn_revert`
-Revertir cambios locales en archivos.
+Revert local changes on files.
 
 ```
 svn_revert(paths: string | string[])
 ```
 
-### Herramientas de Mantenimiento
+### Maintenance Tools
 
 #### `svn_cleanup`
-Limpiar working copy de operaciones interrumpidas.
+Clean up the working copy from interrupted operations.
 
 ```
 svn_cleanup(path?: string)
 ```
 
-## 📖 Ejemplos de Uso
+## 📖 Usage Examples
 
-### Verificar estado del sistema
+### Check the system status
 
 ```javascript
-// Verificar que SVN esté disponible y el working copy sea válido
+// Check that SVN is available and the working copy is valid
 const healthCheck = await svn_health_check();
 ```
 
-### Obtener información del repositorio
+### Get repository information
 
 ```javascript
-// Información general del working copy
+// General working copy information
 const info = await svn_info();
 
-// Información de un archivo específico
+// Information about a specific file
 const fileInfo = await svn_info("src/main.js");
 ```
 
-### Ver estado de archivos
+### Show file status
 
 ```javascript
-// Estado de todos los archivos
+// Status of all files
 const status = await svn_status();
 
-// Estado con información remota
+// Status including remote information
 const fullStatus = await svn_status(null, true);
 ```
 
-### Hacer checkout de un repositorio
+### Check out a repository
 
 ```javascript
 const checkout = await svn_checkout(
@@ -395,13 +403,13 @@ const checkout = await svn_checkout(
 );
 ```
 
-### Confirmar cambios
+### Commit changes
 
 ```javascript
-// Añadir archivos
+// Add files
 await svn_add(["src/new-file.js", "docs/readme.md"], { parents: true });
 
-// Hacer commit
+// Commit
 await svn_commit(
   "Add new feature and documentation",
   ["src/new-file.js", "docs/readme.md"]
@@ -411,43 +419,43 @@ await svn_commit(
 ## 🧪 Testing
 
 ```bash
-# Ejecutar tests
+# Run tests
 npm test
 
-# Tests con cobertura
+# Tests with coverage
 npm run test -- --coverage
 
-# Tests en modo watch
+# Tests in watch mode
 npm run test -- --watch
 ```
 
-## 🏗️ Desarrollo
+## 🏗️ Development
 
-### Scripts disponibles
+### Available scripts
 
 ```bash
-# Compilar TypeScript
+# Build TypeScript
 npm run build
 
-# Modo desarrollo
+# Development mode
 npm run dev
 
-# Modo watch
+# Watch mode
 npm run watch
 
-# Inspector MCP
+# MCP Inspector
 npm run inspector
 
 # Tests
 npm test
 
-# Publicar nueva versión
+# Publish a new version
 npm run release:patch
 npm run release:minor
 npm run release:major
 ```
 
-### Estructura del proyecto
+### Project structure
 
 ```
 svn-mcp/
@@ -456,76 +464,76 @@ svn-mcp/
 ├── jest.config.js
 ├── index.ts
 ├── common/
-│   ├── types.ts      # Tipos TypeScript
-│   ├── utils.ts      # Utilidades para SVN
-│   └── version.ts    # Versión del paquete
+│   ├── types.ts      # TypeScript types
+│   ├── utils.ts      # SVN utilities
+│   └── version.ts    # Package version
 ├── tools/
-│   └── svn-service.ts # Servicio principal SVN
+│   └── svn-service.ts # Main SVN service
 ├── tests/
-│   └── integration.test.ts # Tests de integración
+│   └── integration.test.ts # Integration tests
 └── README.md
 ```
 
-## 📊 Estado del Desarrollo
+## 📊 Development Status
 
-Ver el archivo [SVN_MCP_IMPLEMENTATION.md](./SVN_MCP_IMPLEMENTATION.md) para el checklist completo de implementación.
+See the [SVN_MCP_IMPLEMENTATION.md](./SVN_MCP_IMPLEMENTATION.md) file for the full implementation checklist.
 
-**Progreso actual:** Etapa 1 completada (Operaciones Básicas) ✅
+**Current progress:** Stage 1 complete (Basic Operations) ✅
 
-**Próximas etapas:**
-- Gestión de ramas (branching)
-- Operaciones avanzadas (merge, switch)
-- Herramientas de análisis
-- Operaciones en lote
+**Next stages:**
+- Branch management (branching)
+- Advanced operations (merge, switch)
+- Analysis tools
+- Batch operations
 
 ## 🐛 Troubleshooting
 
-### SVN no encontrado
+### SVN not found
 
 ```
 Error: SVN is not available in the system PATH
 ```
 
-**Solución:** Instalar SVN y asegurarse de que esté en el PATH del sistema.
+**Solution:** Install SVN and make sure it is on the system PATH.
 
-### No es un working copy
+### Not a working copy
 
 ```
 Error: Failed to get SVN info: svn: warning: W155007: '.' is not a working copy
 ```
 
-**Solución:** Navegar a un directorio que sea un working copy de SVN o hacer checkout primero.
+**Solution:** Navigate to a directory that is an SVN working copy or run checkout first.
 
-### Problemas de autenticación
+### Authentication issues
 
 ```
 Error: svn: E170001: Authentication failed
 ```
 
-**Solución:** Configurar las variables de entorno `SVN_USERNAME` y `SVN_PASSWORD`.
+**Solution:** Set the `SVN_USERNAME` and `SVN_PASSWORD` environment variables.
 
-### Timeout en operaciones largas
+### Timeouts on long operations
 
 ```
 Error: Command timeout after 30000ms
 ```
 
-**Solución:** Incrementar el valor de `SVN_TIMEOUT`.
+**Solution:** Increase the value of `SVN_TIMEOUT`.
 
-## 📄 Licencia
+## 📄 License
 
-MIT License - ver [LICENSE](LICENSE) para más detalles.
+MIT License - see [LICENSE](LICENSE) for more details.
 
-## 🤝 Contribuir
+## 🤝 Contributing
 
-1. Fork el proyecto
-2. Crear una rama feature (`git checkout -b feature/nueva-caracteristica`)
-3. Commit los cambios (`git commit -am 'Add nueva caracteristica'`)
-4. Push a la rama (`git push origin feature/nueva-caracteristica`)
-5. Crear un Pull Request
+1. Fork the project
+2. Create a feature branch (`git checkout -b feature/new-feature`)
+3. Commit your changes (`git commit -am 'Add new feature'`)
+4. Push to the branch (`git push origin feature/new-feature`)
+5. Open a Pull Request
 
-## 📞 Soporte
+## 📞 Support
 
 - **Issues:** [GitHub Issues](https://github.com/gcorroto/mcp-svn/issues)
-- **Documentación:** [Wiki del proyecto](https://github.com/gcorroto/mcp-svn/wiki)
-- **Email:** soporte@grec0.dev 
+- **Documentation:** [Project Wiki](https://github.com/gcorroto/mcp-svn/wiki)
+- **Email:** soporte@grec0.dev

--- a/SOLUCION_ERRORES.md
+++ b/SOLUCION_ERRORES.md
@@ -1,128 +1,128 @@
-# Solución de Errores en MCP SVN
+# Error Resolution in MCP SVN
 
-## Problema Reportado
+## Reported Problem
 
-Las funciones `svn_status` y `svn_log` estaban fallando con código de error 1, mientras que `svn_health_check` y `svn_info` funcionaban correctamente.
+The `svn_status` and `svn_log` functions were failing with exit code 1, while `svn_health_check` and `svn_info` were working correctly.
 
-### Errores Específicos:
-- `svn status --show-updates` fallaba con código 1
-- `svn log --limit 15` fallaba con código 1
+### Specific Errors:
+- `svn status --show-updates` failed with exit code 1
+- `svn log --limit 15` failed with exit code 1
 
-## Mejoras Implementadas
+## Improvements Implemented
 
-### 1. Manejo Robusto de `svn_status`
-- **Problema**: `--show-updates` requiere acceso al repositorio remoto
-- **Solución**: Intentar primero con `--show-updates`, si falla, usar solo status local
-- **Beneficio**: La función ahora funciona incluso sin conectividad remota
+### 1. Robust `svn_status` Handling
+- **Problem**: `--show-updates` requires access to the remote repository
+- **Solution**: Try `--show-updates` first; if it fails, fall back to local status only
+- **Benefit**: The function now works even without remote connectivity
 
-### 2. Mejor Manejo de Errores
-- **Mejora**: Mensajes de error más específicos y en español
-- **Códigos de error detectados**:
-  - `E155007`: No es un working copy
-  - `E175002`: Problemas de conexión
-  - `E170001`: Error de autenticación
-  - `E215004`: Demasiados intentos de autenticación (nuevo)
-  - `E155036`: Working copy bloqueado
-  - `E200030`: Error de base de datos SQLite
+### 2. Better Error Handling
+- **Improvement**: More specific error messages
+- **Detected error codes**:
+  - `E155007`: Not a working copy
+  - `E175002`: Connection problems
+  - `E170001`: Authentication error
+  - `E215004`: Too many authentication attempts (new)
+  - `E155036`: Working copy locked
+  - `E200030`: SQLite database error
 
-### 3. Nueva Función de Diagnóstico
-- **Función**: `svn_diagnose`
-- **Propósito**: Probar comandos individualmente para identificar problemas específicos
-- **Información que proporciona**:
-  - Status local (funciona/falla)
-  - Status remoto (funciona/falla)
-  - Log básico (funciona/falla)
-  - Lista de errores específicos
-  - Sugerencias de solución
+### 3. New Diagnostic Function
+- **Function**: `svn_diagnose`
+- **Purpose**: Test commands individually to pinpoint specific problems
+- **Information provided**:
+  - Local status (works/fails)
+  - Remote status (works/fails)
+  - Basic log (works/fails)
+  - List of specific errors
+  - Resolution suggestions
 
-### 4. Nueva Función de Limpieza de Credenciales
-- **Función**: `svn_clear_credentials`
-- **Propósito**: Limpiar cache de credenciales SVN para resolver errores E215004
-- **Beneficio**: Resuelve problemas cuando SVN ha intentado autenticarse demasiadas veces
+### 4. New Credentials Cache Clearing Function
+- **Function**: `svn_clear_credentials`
+- **Purpose**: Clear the SVN credentials cache to resolve E215004 errors
+- **Benefit**: Resolves issues when SVN has attempted authentication too many times
 
-### 5. Parsing Mejorado
-- **svn log**: Parsing más robusto con manejo de casos edge
-- **Validación**: Mejor validación de entrada vacía o malformada
+### 5. Improved Parsing
+- **svn log**: More robust parsing with edge-case handling
+- **Validation**: Better validation of empty or malformed input
 
-## Cómo Usar las Mejoras
+## How to Use the Improvements
 
-### 1. Ejecutar Diagnóstico
+### 1. Run Diagnostics
 ```bash
-# Usar la nueva función de diagnóstico
+# Use the new diagnostic function
 svn_diagnose
 ```
 
-### 2. Verificar Estado del Sistema
+### 2. Check System Health
 ```bash
-# Health check básico
+# Basic health check
 svn_health_check
 ```
 
-### 3. Limpiar Cache de Credenciales (Nuevo)
+### 3. Clear Credentials Cache (New)
 ```bash
-# Limpiar credenciales cacheadas (para resolver E215004)
+# Clear cached credentials (to resolve E215004)
 svn_clear_credentials
 ```
 
-### 4. Obtener Status (Mejorado)
+### 4. Get Status (Improved)
 ```bash
-# Ahora funciona incluso sin conexión remota
+# Now works even without a remote connection
 svn_status
 ```
 
-## Posibles Causas de los Errores Originales
+## Possible Causes of the Original Errors
 
-### 1. Problemas de Conectividad
-- Repositorio SVN no accesible
-- Firewall o proxy bloqueando conexiones
-- Servidor SVN temporalmente inaccesible
+### 1. Connectivity Problems
+- SVN repository unreachable
+- Firewall or proxy blocking connections
+- SVN server temporarily inaccessible
 
-### 2. Problemas de Autenticación
-- Credenciales incorrectas
-- Usuario sin permisos suficientes
-- Sesión de autenticación expirada
+### 2. Authentication Problems
+- Incorrect credentials
+- User without sufficient permissions
+- Authentication session expired
 
-### 3. Problemas del Working Copy
-- Working copy corrupto
-- Base de datos SVN (.svn) dañada
-- Locks de procesos anteriores
+### 3. Working Copy Problems
+- Corrupt working copy
+- Damaged SVN database (.svn)
+- Locks from previous processes
 
-### 4. Configuración del Entorno
-- SVN no está en el PATH
-- Variables de entorno incorrectas
-- Permisos de archivos/directorios
+### 4. Environment Configuration
+- SVN is not in PATH
+- Incorrect environment variables
+- File/directory permissions
 
-## Soluciones Recomendadas
+## Recommended Solutions
 
-### Para Problemas de Conectividad:
-1. Verificar conexión a internet
-2. Probar acceso manual al repositorio
-3. Verificar configuración de proxy/firewall
+### For Connectivity Problems:
+1. Check internet connectivity
+2. Try accessing the repository manually
+3. Check proxy/firewall configuration
 
-### Para Problemas de Autenticación:
-1. Verificar credenciales en variables de entorno
-2. Probar login manual con SVN  
-3. Renovar credenciales si han expirado
-4. **Nuevo:** Si aparece el error E215004 "No more credentials or we tried too many times", usar `svn_clear_credentials` para limpiar el cache de credenciales
+### For Authentication Problems:
+1. Check credentials in environment variables
+2. Try logging in manually with SVN
+3. Renew credentials if they have expired
+4. **New:** If the E215004 error "No more credentials or we tried too many times" appears, use `svn_clear_credentials` to clear the credentials cache
 
-### Para Problemas del Working Copy:
-1. Ejecutar `svn cleanup`
-2. Actualizar el working copy: `svn update`
-3. En casos extremos, hacer checkout nuevamente
+### For Working Copy Problems:
+1. Run `svn cleanup`
+2. Update the working copy: `svn update`
+3. In extreme cases, run checkout again
 
-### Para Problemas de Configuración:
-1. Verificar que SVN esté instalado y en PATH
-2. Revisar variables de entorno SVN_*
-3. Verificar permisos de directorio
+### For Configuration Problems:
+1. Make sure SVN is installed and in PATH
+2. Review the SVN_* environment variables
+3. Check directory permissions
 
 ## Testing
 
-Las mejoras incluyen:
-- Fallback automático cuando fallan comandos remotos
-- Mensajes de error más informativos
-- Función de diagnóstico para identificar problemas específicos
-- Parsing más robusto de outputs de SVN
+The improvements include:
+- Automatic fallback when remote commands fail
+- More informative error messages
+- Diagnostic function to pinpoint specific problems
+- More robust parsing of SVN output
 
-## Compatibilidad
+## Compatibility
 
-Estas mejoras son compatibles con versiones existentes y no rompen la funcionalidad actual. Solo mejoran la robustez y el manejo de errores. 
+These improvements are backward compatible and do not break existing behavior. They only improve robustness and error handling.

--- a/SVN_MCP_IMPLEMENTATION.md
+++ b/SVN_MCP_IMPLEMENTATION.md
@@ -1,81 +1,81 @@
-# SVN MCP - Implementación por Etapas
+# SVN MCP - Staged Implementation
 
-## 🎯 Objetivo
-Crear un MCP (Model Context Protocol) completo para Subversion (SVN) que permita a agentes de IA:
-- Entender la estructura de ramas y repositorios
-- Ver cambios y historial
-- Realizar todas las operaciones SVN disponibles
-- Funcionar correctamente en entornos Windows
+## 🎯 Goal
+Build a complete MCP (Model Context Protocol) server for Subversion (SVN) that allows AI agents to:
+- Understand branch and repository structure
+- View changes and history
+- Perform every available SVN operation
+- Work correctly on Windows environments
 
-## 📋 Checklist de Implementación
+## 📋 Implementation Checklist
 
-### Etapa 1: Estructura Base del Proyecto ✅
-- [x] Crear estructura de directorios
-- [x] Configurar package.json
-- [x] Configurar TypeScript (tsconfig.json)
-- [x] Crear archivo de versión
-- [x] Configurar tipos básicos
-- [x] Crear utilidades para ejecutar comandos SVN
+### Stage 1: Project Base Structure ✅
+- [x] Create directory structure
+- [x] Set up package.json
+- [x] Set up TypeScript (tsconfig.json)
+- [x] Create version file
+- [x] Set up base types
+- [x] Create utilities to execute SVN commands
 
-### Etapa 2: Operaciones Básicas de Repositorio ✅
-- [x] **svn_info** - Obtener información del repositorio
-- [x] **svn_status** - Ver estado de archivos
-- [x] **svn_log** - Ver historial de commits
-- [x] **svn_diff** - Ver diferencias entre versiones
-- [x] **svn_checkout** - Clonar repositorio
-- [x] **svn_update** - Actualizar working copy
+### Stage 2: Basic Repository Operations ✅
+- [x] **svn_info** - Get repository information
+- [x] **svn_status** - Show file status
+- [x] **svn_log** - Show commit history
+- [x] **svn_diff** - Show differences between revisions
+- [x] **svn_checkout** - Clone repository
+- [x] **svn_update** - Update working copy
 
-### Etapa 3: Gestión de Archivos ✅
-- [x] **svn_add** - Añadir archivos al control de versiones
-- [x] **svn_delete** - Eliminar archivos
-- [ ] **svn_move** - Mover/renombrar archivos
-- [ ] **svn_copy** - Copiar archivos
-- [x] **svn_revert** - Revertir cambios
-- [x] **svn_commit** - Confirmar cambios
+### Stage 3: File Management ✅
+- [x] **svn_add** - Add files to version control
+- [x] **svn_delete** - Remove files
+- [ ] **svn_move** - Move/rename files
+- [ ] **svn_copy** - Copy files
+- [x] **svn_revert** - Revert changes
+- [x] **svn_commit** - Commit changes
 
-### Etapa 4: Gestión de Ramas (Branching) 🔄
-- [ ] **svn_branch_create** - Crear nueva rama
-- [ ] **svn_branch_list** - Listar ramas existentes
-- [ ] **svn_branch_switch** - Cambiar de rama
-- [ ] **svn_branch_merge** - Fusionar ramas
-- [ ] **svn_branch_delete** - Eliminar rama
+### Stage 4: Branch Management 🔄
+- [ ] **svn_branch_create** - Create a new branch
+- [ ] **svn_branch_list** - List existing branches
+- [ ] **svn_branch_switch** - Switch branches
+- [ ] **svn_branch_merge** - Merge branches
+- [ ] **svn_branch_delete** - Delete a branch
 
-### Etapa 5: Operaciones Avanzadas 🔄
-- [ ] **svn_resolve** - Resolver conflictos
-- [ ] **svn_import** - Importar proyecto
-- [ ] **svn_export** - Exportar sin metadatos
-- [ ] **svn_relocate** - Cambiar URL del repositorio
-- [ ] **svn_cleanup** - Limpiar working copy
-- [ ] **svn_lock** - Bloquear archivos
-- [ ] **svn_unlock** - Desbloquear archivos
+### Stage 5: Advanced Operations 🔄
+- [ ] **svn_resolve** - Resolve conflicts
+- [ ] **svn_import** - Import a project
+- [ ] **svn_export** - Export without metadata
+- [ ] **svn_relocate** - Change the repository URL
+- [x] **svn_cleanup** - Clean up the working copy
+- [ ] **svn_lock** - Lock files
+- [ ] **svn_unlock** - Unlock files
 
-### Etapa 6: Análisis y Reporting 🔄
-- [ ] **svn_blame** - Ver quién modificó cada línea
-- [ ] **svn_list** - Listar contenido del repositorio
-- [ ] **svn_cat** - Ver contenido de archivo
-- [ ] **svn_propget** - Obtener propiedades
-- [ ] **svn_propset** - Establecer propiedades
-- [ ] **svn_propdel** - Eliminar propiedades
+### Stage 6: Analysis and Reporting 🔄
+- [ ] **svn_blame** - Show who modified each line
+- [x] **svn_list** - List repository contents
+- [x] **svn_cat** - Show file contents
+- [ ] **svn_propget** - Get properties
+- [ ] **svn_propset** - Set properties
+- [ ] **svn_propdel** - Delete properties
 
-### Etapa 7: Herramientas de Productividad 🔄
-- [ ] **svn_working_copy_summary** - Resumen completo del working copy
-- [ ] **svn_branch_comparison** - Comparar ramas
-- [ ] **svn_conflict_detector** - Detectar conflictos potenciales
-- [ ] **svn_health_check** - Verificar estado del repositorio
-- [ ] **svn_batch_operations** - Operaciones en lote
+### Stage 7: Productivity Tools 🔄
+- [ ] **svn_working_copy_summary** - Complete working copy summary
+- [ ] **svn_branch_comparison** - Compare branches
+- [ ] **svn_conflict_detector** - Detect potential conflicts
+- [ ] **svn_health_check** - Check repository health
+- [ ] **svn_batch_operations** - Batch operations
 
-### Etapa 8: Testing y Optimización 🔄
-- [ ] Crear tests unitarios
-- [ ] Manejo de errores robusto
-- [ ] Optimización de rendimiento
-- [ ] Documentación completa
-- [ ] Validación en Windows
+### Stage 8: Testing and Optimization 🔄
+- [ ] Create unit tests
+- [ ] Robust error handling
+- [ ] Performance optimization
+- [ ] Complete documentation
+- [ ] Validation on Windows
 
 ---
 
-## 🛠️ Comandos SVN a Implementar
+## 🛠️ SVN Commands to Implement
 
-### Comandos Básicos
+### Basic Commands
 ```bash
 svn checkout (co)     # Checkout working copy
 svn update (up)       # Update working copy
@@ -88,7 +88,7 @@ svn log               # Show log messages
 svn diff (di)         # Show differences
 ```
 
-### Comandos de Archivos
+### File Commands
 ```bash
 svn copy (cp)         # Copy files/directories
 svn move (mv/rename)  # Move/rename files
@@ -98,7 +98,7 @@ svn cat               # Output file contents
 svn list (ls)         # List directory entries
 ```
 
-### Comandos de Ramas
+### Branch Commands
 ```bash
 svn switch (sw)       # Switch working copy to different URL
 svn merge             # Merge changes
@@ -106,7 +106,7 @@ svn import            # Import files into repository
 svn export            # Export clean directory tree
 ```
 
-### Comandos de Propiedades
+### Property Commands
 ```bash
 svn propget (pget/pg) # Get property value
 svn propset (pset/ps) # Set property value
@@ -114,7 +114,7 @@ svn propdel (pdel/pd) # Delete property
 svn proplist (plist/pl) # List properties
 ```
 
-### Comandos de Administración
+### Administration Commands
 ```bash
 svn cleanup           # Clean up working copy
 svn relocate          # Relocate working copy
@@ -125,9 +125,9 @@ svn blame (praise/annotate) # Show file annotations
 
 ---
 
-## 🔧 Implementación Técnica
+## 🔧 Technical Implementation
 
-### Estructura de Archivos
+### File Structure
 ```
 svn-mcp/
 ├── package.json
@@ -147,85 +147,85 @@ svn-mcp/
 └── README.md
 ```
 
-### Consideraciones para Windows
-- Usar `child_process.spawn()` con `shell: true`
-- Manejar rutas con `path.resolve()` y `path.normalize()`
-- Escapar argumentos correctamente
-- Detectar si SVN está instalado y disponible en PATH
-- Manejar encoding de caracteres especiales
+### Windows Considerations
+- Use `child_process.spawn()` with `shell: true`
+- Handle paths with `path.resolve()` and `path.normalize()`
+- Escape arguments correctly
+- Detect whether SVN is installed and available on PATH
+- Handle encoding of special characters
 
-### Manejo de Errores
-- Capturar stderr de comandos SVN
-- Parsear códigos de error específicos
-- Proporcionar mensajes de error claros
-- Manejar timeouts de operaciones largas
-
----
-
-## 📊 Progreso Actual
-
-**Completado:** 14/40 tareas (35%)
-
-**Etapa Actual:** Operaciones Básicas de Repositorio ✅
-
-**Próxima Etapa:** Gestión de Archivos
-
-### ✅ Completado Recientemente:
-- [x] Estructura base del proyecto
-- [x] Configuración de TypeScript y Jest
-- [x] **svn_health_check** - Verificar sistema SVN
-- [x] **svn_info** - Obtener información del repositorio
-- [x] **svn_status** - Ver estado de archivos
-- [x] **svn_log** - Ver historial de commits
-- [x] **svn_diff** - Ver diferencias entre versiones
-- [x] **svn_checkout** - Clonar repositorio
-- [x] **svn_update** - Actualizar working copy
-- [x] **svn_add** - Añadir archivos al control de versiones
-- [x] **svn_commit** - Confirmar cambios
-- [x] **svn_delete** - Eliminar archivos
-- [x] **svn_revert** - Revertir cambios
-- [x] **svn_cleanup** - Limpiar working copy
+### Error Handling
+- Capture stderr from SVN commands
+- Parse specific error codes
+- Provide clear error messages
+- Handle timeouts of long-running operations
 
 ---
 
-## 🚀 Comandos de Desarrollo
+## 📊 Current Progress
+
+**Completed:** 14/40 tasks (35%)
+
+**Current Stage:** Basic Repository Operations ✅
+
+**Next Stage:** File Management
+
+### ✅ Recently Completed:
+- [x] Project base structure
+- [x] TypeScript and Jest setup
+- [x] **svn_health_check** - Check SVN system
+- [x] **svn_info** - Get repository information
+- [x] **svn_status** - Show file status
+- [x] **svn_log** - Show commit history
+- [x] **svn_diff** - Show differences between revisions
+- [x] **svn_checkout** - Clone repository
+- [x] **svn_update** - Update working copy
+- [x] **svn_add** - Add files to version control
+- [x] **svn_commit** - Commit changes
+- [x] **svn_delete** - Remove files
+- [x] **svn_revert** - Revert changes
+- [x] **svn_cleanup** - Clean up working copy
+
+---
+
+## 🚀 Development Commands
 
 ```bash
-# Instalar dependencias
+# Install dependencies
 npm install
 
-# Compilar TypeScript
+# Build TypeScript
 npm run build
 
-# Ejecutar en modo desarrollo
+# Run in development mode
 npm run dev
 
-# Ejecutar tests
+# Run tests
 npm test
 
-# Compilar y publicar
+# Build and publish
 npm run release
 ```
 
 ---
 
-## 📝 Notas de Implementación
+## 📝 Implementation Notes
 
-### Comando Base SVN
-Todos los comandos utilizarán la estructura:
+### Base SVN Command
+Every command uses the structure:
 ```typescript
 svn [command] [options] [arguments]
 ```
 
-### Formato de Respuesta
-Todas las herramientas devolverán JSON estructurado con:
+### Response Format
+All tools return structured JSON with:
 - `success`: boolean
-- `data`: resultado del comando
-- `error`: mensaje de error si aplica
-- `command`: comando ejecutado
-- `workingDirectory`: directorio de trabajo
+- `data`: command result
+- `error`: error message if applicable
+- `command`: executed command
+- `workingDirectory`: working directory
 
-### Autenticación
-- Soporte para credenciales mediante variables de entorno
-- Manejo de autenticación por certificados
-- Cache de credenciales cuando sea posible 
+### Authentication
+- Support for credentials via environment variables
+- Support for certificate-based authentication
+- Credentials cache when possible

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,44 +1,44 @@
-# 🔧 Solución de Problemas - MCP SVN
+# 🔧 Troubleshooting - MCP SVN
 
-## Problema: "not a working copy"
+## Problem: "not a working copy"
 
-### Error típico:
+### Typical error:
 ```
-❌ Error: El directorio 'C:\tu\directorio' no es un working copy de SVN. 
-Asegúrate de estar en un directorio que contenga un repositorio SVN o hacer checkout primero.
+❌ Error: The directory 'C:\your\directory' is not an SVN working copy.
+Make sure you are in a directory that contains an SVN repository or run checkout first.
 ```
 
-### Causa:
-Este error ocurre cuando intentas ejecutar comandos SVN (`svn info`, `svn status`, etc.) en un directorio que **no está bajo control de versiones SVN**.
+### Cause:
+This error occurs when you try to execute SVN commands (`svn info`, `svn status`, etc.) in a directory that **is not under SVN version control**.
 
-### Soluciones:
+### Solutions:
 
-#### 1. **Cambiar al directorio correcto**
-Si ya tienes un working copy SVN en otro lugar:
+#### 1. **Switch to the correct directory**
+If you already have an SVN working copy elsewhere:
 
 ```bash
-# Configurar la variable de entorno para apuntar a tu working copy
-export SVN_WORKING_DIRECTORY="/ruta/a/tu/working-copy"
+# Configure the environment variable to point to your working copy
+export SVN_WORKING_DIRECTORY="/path/to/your/working-copy"
 ```
 
-En Windows:
+On Windows:
 ```cmd
-set SVN_WORKING_DIRECTORY=C:\ruta\a\tu\working-copy
+set SVN_WORKING_DIRECTORY=C:\path\to\your\working-copy
 ```
 
-#### 2. **Hacer checkout de un repositorio**
-Si necesitas crear un working copy nuevo:
+#### 2. **Check out a repository**
+If you need to create a fresh working copy:
 
 ```bash
-# Usar la herramienta svn_checkout del MCP
+# Use the svn_checkout tool from the MCP
 svn_checkout(
-  url: "https://tu-servidor-svn.com/repo/trunk",
-  path: "mi-proyecto"
+  url: "https://your-svn-server.com/repo/trunk",
+  path: "my-project"
 )
 ```
 
-#### 3. **Verificar si un directorio es working copy**
-Busca la carpeta `.svn` oculta:
+#### 3. **Check whether a directory is a working copy**
+Look for the hidden `.svn` folder:
 
 **Windows (PowerShell):**
 ```powershell
@@ -50,18 +50,18 @@ Get-ChildItem -Force | Where-Object {$_.Name -like ".svn*"}
 ls -la | grep .svn
 ```
 
-## Configuración del Entorno
+## Environment Configuration
 
-### Variables de Entorno Importantes
+### Important Environment Variables
 
-| Variable | Descripción | Ejemplo |
+| Variable | Description | Example |
 |----------|-------------|---------|
-| `SVN_PATH` | Ruta del ejecutable SVN | `C:/Program Files/TortoiseSVN/bin/svn.exe` |
-| `SVN_WORKING_DIRECTORY` | Directorio de trabajo | `C:/mi-proyecto` |
-| `SVN_USERNAME` | Usuario para autenticación | `usuario@empresa.com` |
-| `SVN_PASSWORD` | Contraseña | `mi-contraseña` |
+| `SVN_PATH` | Path to the SVN executable | `C:/Program Files/TortoiseSVN/bin/svn.exe` |
+| `SVN_WORKING_DIRECTORY` | Working directory | `C:/my-project` |
+| `SVN_USERNAME` | Authentication user | `user@company.com` |
+| `SVN_PASSWORD` | Password | `my-password` |
 
-### Ejemplo de configuración MCP
+### Example MCP Configuration
 
 ```json
 {
@@ -71,104 +71,104 @@ ls -la | grep .svn
       "args": ["@grec0/mcp-svn"],
       "env": {
         "SVN_PATH": "C:/Program Files/TortoiseSVN/bin/svn.exe",
-        "SVN_WORKING_DIRECTORY": "C:/mi-proyecto",
-        "SVN_USERNAME": "mi-usuario",
-        "SVN_PASSWORD": "mi-contraseña"
+        "SVN_WORKING_DIRECTORY": "C:/my-project",
+        "SVN_USERNAME": "my-user",
+        "SVN_PASSWORD": "my-password"
       }
     }
   }
 }
 ```
 
-## Verificación del Sistema
+## System Verification
 
-### 1. Verificar instalación de SVN
+### 1. Verify the SVN installation
 ```bash
 svn --version
 ```
 
-### 2. Verificar que el MCP funciona
-Usa la herramienta `svn_health_check()` para verificar:
-- ✅ SVN está disponible
-- ✅ Working copy es válido
-- ✅ Repositorio es accesible
+### 2. Verify that the MCP works
+Use the `svn_health_check()` tool to verify:
+- ✅ SVN is available
+- ✅ Working copy is valid
+- ✅ Repository is accessible
 
-### 3. Testear comandos básicos
+### 3. Test basic commands
 ```bash
-# Verificar info del working copy
+# Check the working copy info
 svn info
 
-# Ver estado de archivos
+# Show file status
 svn status
 ```
 
-## Flujo de Trabajo Típico
+## Typical Workflow
 
-### 1. **Primer uso - Hacer checkout**
+### 1. **First use - Check out**
 ```
-1. svn_checkout(url: "https://servidor/repo", path: "mi-proyecto")
-2. Configurar SVN_WORKING_DIRECTORY hacia "mi-proyecto"
-3. Usar otros comandos SVN
-```
-
-### 2. **Uso regular - Trabajar con archivos**
-```
-1. svn_info() - Ver información del repositorio
-2. svn_status() - Ver archivos modificados
-3. svn_add(paths: ["nuevo-archivo.txt"])
-4. svn_commit(message: "Añadir nuevo archivo")
+1. svn_checkout(url: "https://server/repo", path: "my-project")
+2. Configure SVN_WORKING_DIRECTORY to point to "my-project"
+3. Use the other SVN commands
 ```
 
-### 3. **Mantenimiento**
+### 2. **Regular use - Working with files**
 ```
-1. svn_update() - Actualizar desde el servidor
-2. svn_cleanup() - Limpiar working copy si hay problemas
+1. svn_info() - Get repository information
+2. svn_status() - Show modified files
+3. svn_add(paths: ["new-file.txt"])
+4. svn_commit(message: "Add new file")
 ```
 
-## Errores Comunes y Soluciones
+### 3. **Maintenance**
+```
+1. svn_update() - Update from the server
+2. svn_cleanup() - Clean up the working copy if there are issues
+```
+
+## Common Errors and Solutions
 
 ### Error: "SVN command failed with code 1"
-- **Causa**: Comando SVN falló
-- **Solución**: Ver el mensaje de error específico para más detalles
+- **Cause**: SVN command failed
+- **Solution**: Check the specific error message for details
 
 ### Error: "SVN is not available"
-- **Causa**: SVN no está instalado o no está en PATH
-- **Solución**: Instalar SVN o configurar SVN_PATH
+- **Cause**: SVN is not installed or not on PATH
+- **Solution**: Install SVN or configure SVN_PATH
 
 ### Error: "Authentication failed"
-- **Causa**: Credenciales incorrectas
-- **Solución**: Verificar SVN_USERNAME y SVN_PASSWORD
+- **Cause**: Incorrect credentials
+- **Solution**: Check SVN_USERNAME and SVN_PASSWORD
 
 ### Error: "E215004: No more credentials or we tried too many times"
-- **Causa**: Demasiados intentos de autenticación fallidos - credenciales pueden estar cacheadas incorrectamente
-- **Solución**: Ejecutar `svn_clear_credentials()` para limpiar el cache de credenciales SVN
+- **Cause**: Too many failed authentication attempts — credentials may be incorrectly cached
+- **Solution**: Run `svn_clear_credentials()` to clear the SVN credentials cache
 
 ### Error: "Working copy locked"
-- **Causa**: Operación SVN anterior se interrumpió
-- **Solución**: Ejecutar `svn_cleanup()`
+- **Cause**: A previous SVN operation was interrupted
+- **Solution**: Run `svn_cleanup()`
 
-## Herramientas de Diagnóstico
+## Diagnostic Tools
 
-### Comando de diagnóstico completo
+### Full diagnostic command
 ```javascript
-// Verificar todo el sistema
+// Check the entire system
 await svn_health_check();
 
-// Si hay problemas, verificar paso a paso:
-1. Verificar SVN: svn --version
-2. Verificar directorio: ls -la .svn
-3. Verificar conexión: svn info --non-interactive
+// If there are issues, check step by step:
+1. Check SVN: svn --version
+2. Check the directory: ls -la .svn
+3. Check the connection: svn info --non-interactive
 ```
 
-## Soporte
+## Support
 
-Si el problema persiste después de seguir esta guía:
+If the problem persists after following this guide:
 
-1. **Revisar los logs** del MCP para errores específicos
-2. **Verificar permisos** de archivos y directorios
-3. **Probar comandos SVN manualmente** en la terminal
-4. **Verificar conectividad** al servidor SVN
+1. **Review the logs** of the MCP for specific errors
+2. **Check permissions** on files and directories
+3. **Test SVN commands manually** in the terminal
+4. **Check connectivity** to the SVN server
 
 ---
 
-**💡 Consejo**: Siempre ejecuta `svn_health_check()` primero para diagnosticar problemas de configuración. 
+**💡 Tip**: Always run `svn_health_check()` first to diagnose configuration issues.

--- a/common/types.ts
+++ b/common/types.ts
@@ -1,8 +1,14 @@
-// ===== TIPOS BASE =====
+// ===== BASE TYPES =====
 
 export interface SvnConfig {
   svnPath?: string;
   workingDirectory?: string;
+  /**
+   * Repository URL. When set, bare repo-relative targets like
+   * `/trunk/file.sql` are resolved against it, and URL-only workflows
+   * no longer require a working copy.
+   */
+  url?: string;
   username?: string;
   password?: string;
   timeout?: number;
@@ -28,7 +34,7 @@ export class SvnError extends Error {
   }
 }
 
-// ===== TIPOS DE INFORMACIÓN DEL REPOSITORIO =====
+// ===== REPOSITORY INFORMATION TYPES =====
 
 export interface SvnInfo {
   path: string;
@@ -71,7 +77,7 @@ export interface SvnChangedPath {
   copyFromRev?: number;
 }
 
-// ===== TIPOS DE DIFERENCIAS =====
+// ===== DIFF TYPES =====
 
 export interface SvnDiff {
   oldPath: string;
@@ -96,7 +102,7 @@ export interface SvnDiffLine {
   newLineNumber?: number;
 }
 
-// ===== TIPOS DE RAMAS =====
+// ===== BRANCH TYPES =====
 
 export interface SvnBranch {
   name: string;
@@ -112,7 +118,7 @@ export interface SvnMergeInfo {
   eligibleRevisions: number[];
 }
 
-// ===== TIPOS DE PROPIEDADES =====
+// ===== PROPERTY TYPES =====
 
 export interface SvnProperty {
   name: string;
@@ -125,7 +131,7 @@ export interface SvnPropertyList {
   properties: Record<string, string>;
 }
 
-// ===== TIPOS DE LOCK =====
+// ===== LOCK TYPES =====
 
 export interface SvnLock {
   path: string;
@@ -136,7 +142,7 @@ export interface SvnLock {
   expires?: string;
 }
 
-// ===== TIPOS DE BLAME/ANNOTATION =====
+// ===== BLAME/ANNOTATION TYPES =====
 
 export interface SvnBlameLine {
   revision: number;
@@ -151,7 +157,7 @@ export interface SvnBlame {
   lines: SvnBlameLine[];
 }
 
-// ===== TIPOS PARA OPERACIONES DE ARCHIVOS =====
+// ===== FILE OPERATION TYPES =====
 
 export interface SvnAddOptions {
   force?: boolean;
@@ -202,7 +208,7 @@ export interface SvnDeleteOptions {
   keepLocal?: boolean;
 }
 
-// ===== TIPOS PARA MERGE =====
+// ===== MERGE TYPES =====
 
 export interface SvnMergeOptions {
   dryRun?: boolean;
@@ -212,7 +218,7 @@ export interface SvnMergeOptions {
   acceptConflicts?: 'postpone' | 'base' | 'mine-conflict' | 'theirs-conflict' | 'mine-full' | 'theirs-full';
 }
 
-// ===== TIPOS PARA SWITCH =====
+// ===== SWITCH TYPES =====
 
 export interface SvnSwitchOptions {
   revision?: number | 'HEAD';
@@ -221,14 +227,14 @@ export interface SvnSwitchOptions {
   acceptConflicts?: 'postpone' | 'base' | 'mine-conflict' | 'theirs-conflict' | 'mine-full' | 'theirs-full';
 }
 
-// ===== TIPOS PARA RESOLVE =====
+// ===== RESOLVE TYPES =====
 
 export interface SvnResolveOptions {
   accept: 'base' | 'working' | 'mine-conflict' | 'theirs-conflict' | 'mine-full' | 'theirs-full';
   recursive?: boolean;
 }
 
-// ===== TIPOS PARA IMPORT/EXPORT =====
+// ===== IMPORT/EXPORT TYPES =====
 
 export interface SvnImportOptions {
   message: string;
@@ -245,7 +251,30 @@ export interface SvnExportOptions {
   ignoreExternals?: boolean;
 }
 
-// ===== TIPOS PARA HERRAMIENTAS DE ANÁLISIS =====
+// ===== CAT / LIST TYPES =====
+
+export interface SvnCatOptions {
+  revision?: number | 'HEAD' | 'BASE' | 'COMMITTED' | 'PREV' | string;
+}
+
+export interface SvnListOptions {
+  revision?: number | 'HEAD' | 'BASE' | 'COMMITTED' | 'PREV' | string;
+  verbose?: boolean;
+  recursive?: boolean;
+  depth?: 'empty' | 'files' | 'immediates' | 'infinity';
+  includeExternals?: boolean;
+}
+
+export interface SvnListEntry {
+  name: string;
+  kind: 'file' | 'dir';
+  size?: number;
+  revision?: number;
+  author?: string;
+  date?: string;
+}
+
+// ===== ANALYSIS TOOL TYPES =====
 
 export interface SvnWorkingCopySummary {
   info: SvnInfo;
@@ -285,7 +314,7 @@ export interface SvnHealthIssue {
   suggestion?: string;
 }
 
-// ===== TIPOS PARA OPERACIONES EN LOTE =====
+// ===== BATCH OPERATION TYPES =====
 
 export interface SvnBatchOperation {
   type: 'add' | 'delete' | 'move' | 'copy' | 'revert';
@@ -301,7 +330,7 @@ export interface SvnBatchResult {
   result?: any;
 }
 
-// ===== CONSTANTES =====
+// ===== CONSTANTS =====
 
 export const SVN_STATUS_CODES = {
   ' ': 'none',

--- a/common/utils.ts
+++ b/common/utils.ts
@@ -2,16 +2,44 @@ import { spawn, SpawnOptions } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
-import { SvnConfig, SvnResponse, SvnError, SvnInfo, SvnStatus, SvnLogEntry, SVN_STATUS_CODES } from './types.js';
+import { SvnConfig, SvnResponse, SvnError, SvnInfo, SvnStatus, SvnLogEntry, SvnListEntry, SVN_STATUS_CODES } from './types.js';
 import iconv from 'iconv-lite';
 
 /**
- * Crear configuración de SVN desde variables de entorno y parámetros
+ * Create SVN configuration from environment variables and parameters.
+ *
+ * Environment variables:
+ *   SVN_PATH                - path to the svn executable (default: 'svn')
+ *   SVN_WORKING_DIRECTORY   - local working-copy directory (optional)
+ *   SVN_URL / SVN_REPOSITORY_URL - repository URL (optional; used to
+ *                             resolve repo-relative targets like
+ *                             `/trunk/file.sql` and to run URL-only
+ *                             commands without a working copy)
+ *   SVN_USERNAME, SVN_PASSWORD
+ *   SVN_TIMEOUT             - command timeout in ms (default: 30000)
  */
 export function createSvnConfig(overrides: Partial<SvnConfig> = {}): SvnConfig {
+  const envWorkingDir = process.env.SVN_WORKING_DIRECTORY;
+  let workingDirectory = overrides.workingDirectory || envWorkingDir || process.cwd();
+  let url = overrides.url || process.env.SVN_URL || process.env.SVN_REPOSITORY_URL;
+
+  // Backward-compat: SVN_WORKING_DIRECTORY used to be overloaded with a
+  // repository URL. Promote it to `url` and fall back cwd to something
+  // valid, but warn so the user migrates to SVN_URL.
+  if (!overrides.workingDirectory && envWorkingDir && validateSvnUrl(envWorkingDir)) {
+    if (!url) url = envWorkingDir;
+    workingDirectory = process.cwd();
+    console.warn(
+      `[svn-mcp] SVN_WORKING_DIRECTORY is set to a URL ("${envWorkingDir}"). ` +
+      `Treating it as SVN_URL for backward compatibility. ` +
+      `Please migrate to SVN_URL and set SVN_WORKING_DIRECTORY to a local path (or unset it).`
+    );
+  }
+
   return {
     svnPath: overrides.svnPath || process.env.SVN_PATH || 'svn',
-    workingDirectory: overrides.workingDirectory || process.env.SVN_WORKING_DIRECTORY || process.cwd(),
+    workingDirectory,
+    url,
     username: overrides.username || process.env.SVN_USERNAME,
     password: overrides.password || process.env.SVN_PASSWORD,
     timeout: overrides.timeout || parseInt(process.env.SVN_TIMEOUT || '30000', 10)
@@ -19,7 +47,7 @@ export function createSvnConfig(overrides: Partial<SvnConfig> = {}): SvnConfig {
 }
 
 /**
- * Validar que SVN esté disponible en el sistema
+ * Validate that SVN is available on the system
  */
 export async function validateSvnInstallation(config: SvnConfig): Promise<boolean> {
   try {
@@ -31,7 +59,7 @@ export async function validateSvnInstallation(config: SvnConfig): Promise<boolea
 }
 
 /**
- * Detectar si el directorio actual es un working copy de SVN
+ * Detect whether the current directory is an SVN working copy
  */
 export async function isWorkingCopy(workingDirectory: string): Promise<boolean> {
   try {
@@ -43,17 +71,17 @@ export async function isWorkingCopy(workingDirectory: string): Promise<boolean> 
 }
 
 /**
- * Normalizar rutas para Windows
+ * Normalize paths for Windows
  */
 export function normalizePath(filePath: string): string {
   return path.resolve(filePath).replace(/\\/g, '/');
 }
 
 /**
- * Escapar argumentos para línea de comandos en Windows
+ * Escape arguments for the Windows command line
  */
 export function escapeArgument(arg: string): string {
-  // Si el argumento contiene espacios o caracteres especiales, lo encerramos en comillas
+  // If the argument contains spaces or special characters, wrap it in quotes
   if (/[\s&()<>[\]{}^=;!'+,`~%]/.test(arg)) {
     return `"${arg.replace(/"/g, '""')}"`;
   }
@@ -61,7 +89,7 @@ export function escapeArgument(arg: string): string {
 }
 
 /**
- * Construir argumentos de autenticación
+ * Build authentication arguments
  */
 export function buildAuthArgs(config: SvnConfig, options: { noAuthCache?: boolean } = {}): string[] {
   const args: string[] = [];
@@ -74,10 +102,10 @@ export function buildAuthArgs(config: SvnConfig, options: { noAuthCache?: boolea
     args.push('--password', config.password);
   }
   
-  // Siempre usar --non-interactive para evitar prompts
+  // Always use --non-interactive to avoid prompts
   args.push('--non-interactive');
-  
-  // Opción para no usar cache de credenciales (útil para E215004)
+
+  // Option to skip the credentials cache (useful for E215004)
   if (options.noAuthCache) {
     args.push('--no-auth-cache');
   }
@@ -86,7 +114,7 @@ export function buildAuthArgs(config: SvnConfig, options: { noAuthCache?: boolea
 }
 
 /**
- * Ejecutar comando SVN con manejo de errores mejorado
+ * Execute an SVN command with improved error handling
  */
 export async function executeSvnCommand(
   config: SvnConfig,
@@ -95,25 +123,82 @@ export async function executeSvnCommand(
 ): Promise<SvnResponse> {
   const startTime = Date.now();
   
-  // Agregar argumentos de autenticación
+  // Append authentication arguments
   const finalArgs = [...args, ...buildAuthArgs(config, { noAuthCache: options.noAuthCache })];
   const command = `${config.svnPath} ${finalArgs.join(' ')}`;
   
   return new Promise((resolve, reject) => {
-    // Configurar opciones de spawn para Windows
-    const spawnOptions: SpawnOptions = {
-      cwd: config.workingDirectory,
-      shell: true, // Importante para Windows
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        // Asegurar que SVN use UTF-8
-        LANG: 'en_US.UTF-8',
-        LC_ALL: 'en_US.UTF-8'
-      }
+    // We avoid `shell: true` on Windows for two reasons:
+    //   1. Node's shell handling for cmd.exe sets
+    //      windowsVerbatimArguments=true and joins argv with single
+    //      spaces — destroying any argument that contains a space (e.g.
+    //      paths under "Program Files" or repos with spaces in folder
+    //      names). libuv's direct CreateProcess path quotes each argv
+    //      element correctly.
+    //   2. shell:true depends on cmd.exe being resolvable from the
+    //      parent env, which Claude Desktop/Code sometimes sanitizes.
+    //
+    // The only case we still need a shell is when SVN_PATH points at a
+    // .bat/.cmd shim — Node forbids spawning those directly since
+    // 18.20/20.12 (CVE-2024-27980). For that we go through cmd.exe and
+    // pre-escape each arg ourselves so the shell re-parses correctly.
+    const isWindows = process.platform === 'win32';
+    const isBatchShim = isWindows && /\.(bat|cmd)$/i.test(config.svnPath || '');
+    const systemRoot = process.env.SystemRoot || process.env.systemroot || 'C:\\Windows';
+    const system32 = `${systemRoot}\\System32`;
+    const cmdPath = process.env.ComSpec || process.env.comspec || `${system32}\\cmd.exe`;
+
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      // Force SVN to use UTF-8
+      LANG: 'en_US.UTF-8',
+      LC_ALL: 'en_US.UTF-8'
     };
-    
-    const childProcess = spawn(config.svnPath!, finalArgs, spawnOptions);
+
+    if (isWindows) {
+      childEnv.ComSpec = cmdPath;
+      childEnv.SystemRoot = systemRoot;
+
+      // Collapse duplicate-cased PATH entries (Windows inherited env often
+      // ships 'Path'; if we also set 'PATH' the two may race). Keep a
+      // single 'PATH' key and make sure System32 is present.
+      for (const k of Object.keys(childEnv)) {
+        if (k !== 'PATH' && k.toLowerCase() === 'path') delete childEnv[k];
+      }
+      const existingPath = process.env.PATH || process.env.Path || '';
+      const pathParts = existingPath.split(';').filter(Boolean);
+      const hasSystem32 = pathParts.some(p => p.toLowerCase() === system32.toLowerCase());
+      childEnv.PATH = hasSystem32 ? existingPath : [...pathParts, system32].join(';');
+    }
+
+    // Resolve cwd. If SVN_WORKING_DIRECTORY is configured as a repository
+    // URL (valid use case for URL-targeted commands like `svn cat <url>`),
+    // we can't pass it to CreateProcess as cwd — Windows raises
+    // ERROR_PATH_NOT_FOUND which libuv surfaces as a misleading
+    // "spawn <exe> ENOENT" attached to the executable. Fall back to
+    // process.cwd() in that case; URL commands pass the URL as an arg so
+    // cwd doesn't matter, and local commands that need a working copy
+    // won't have been given a URL here.
+    let resolvedCwd = config.workingDirectory;
+    if (!resolvedCwd || validateSvnUrl(resolvedCwd)) {
+      resolvedCwd = process.cwd();
+    }
+
+    const spawnOptions: SpawnOptions = {
+      cwd: resolvedCwd,
+      // Direct spawn (no shell) lets libuv quote argv per element. The
+      // batch-shim case is the only one that has to take the cmd.exe
+      // detour, with manual arg escaping below.
+      shell: isBatchShim ? cmdPath : false,
+      windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: childEnv
+    };
+
+    // Only pre-escape when we're going through a shell — direct spawn
+    // does its own quoting and would double-escape if we did it too.
+    const argsForSpawn = isBatchShim ? finalArgs.map(escapeArgument) : finalArgs;
+    const childProcess = spawn(config.svnPath!, argsForSpawn, spawnOptions);
     
     let stdout = '';
     let stderr = '';
@@ -124,29 +209,29 @@ export async function executeSvnCommand(
     const stdoutDecoder = iconv.getDecoder('utf8', { stripBOM: false, addBOM: false });
     const stderrDecoder = iconv.getDecoder('utf8', { stripBOM: false, addBOM: false });
     
-    // Configurar timeout
+    // Configure timeout
     const timeout = setTimeout(() => {
       childProcess.kill('SIGTERM');
       reject(new SvnError(`Command timeout after ${config.timeout}ms: ${command}`));
     }, config.timeout);
     
-    // Capturar stdout using streaming decoder to handle multi-byte characters correctly
+    // Capture stdout using streaming decoder to handle multi-byte characters correctly
     childProcess.stdout?.on('data', (data) => {
       stdout += stdoutDecoder.write(data);
     });
-    
-    // Capturar stderr using streaming decoder to handle multi-byte characters correctly
+
+    // Capture stderr using streaming decoder to handle multi-byte characters correctly
     childProcess.stderr?.on('data', (data) => {
       stderr += stderrDecoder.write(data);
     });
-    
-    // Enviar input si se proporciona
+
+    // Write input if provided
     if (options.input && childProcess.stdin) {
       childProcess.stdin.write(options.input);
       childProcess.stdin.end();
     }
-    
-    // Manejar finalización del proceso
+
+    // Handle process completion
     childProcess.on('close', (code) => {
       clearTimeout(timeout);
       
@@ -178,7 +263,7 @@ export async function executeSvnCommand(
       }
     });
     
-    // Manejar errores del proceso
+    // Handle process errors
     childProcess.on('error', (error) => {
       clearTimeout(timeout);
       
@@ -191,14 +276,14 @@ export async function executeSvnCommand(
 }
 
 /**
- * Parsear output XML de SVN
+ * Parse SVN XML output
  */
 export function parseXmlOutput(xmlString: string): any {
-  // Implementación básica de parsing XML
-  // En un entorno de producción, sería mejor usar una librería como xml2js
+  // Basic XML parsing implementation
+  // In a production environment it would be better to use a library like xml2js
   try {
-    // Esta es una implementación simplificada para Node.js
-    // En navegadores se usaría DOMParser, pero en Node.js necesitamos otra aproximación
+    // This is a simplified implementation for Node.js
+    // In browsers we would use DOMParser, but in Node.js we need another approach
     const lines = xmlString.split('\n');
     const result: any = {};
     
@@ -216,7 +301,7 @@ export function parseXmlOutput(xmlString: string): any {
 }
 
 /**
- * Parsear información de svn info
+ * Parse output of `svn info`
  */
 export function parseInfoOutput(output: string): SvnInfo {
   const lines = output.split('\n');
@@ -276,7 +361,7 @@ export function parseInfoOutput(output: string): SvnInfo {
 }
 
 /**
- * Parsear output de svn status
+ * Parse output of `svn status`
  */
 export function parseStatusOutput(output: string): SvnStatus[] {
   const lines = output.split('\n').filter(line => line.trim());
@@ -301,24 +386,24 @@ export function parseStatusOutput(output: string): SvnStatus[] {
 }
 
 /**
- * Parsear output de svn log
+ * Parse output of `svn log`
  */
 export function parseLogOutput(output: string): SvnLogEntry[] {
   const entries: SvnLogEntry[] = [];
-  
+
   if (!output || output.trim().length === 0) {
     return entries;
   }
-  
-  // Dividir por las líneas separadoras de SVN log
+
+  // Split on the SVN log separator lines
   const logEntries = output.split(/^-{72}$/gm).filter(entry => entry.trim());
-  
+
   for (const entryText of logEntries) {
     const lines = entryText.trim().split('\n');
     if (lines.length < 2) continue;
-    
+
     const headerLine = lines[0];
-    // Patrón más flexible para el header
+    // Flexible header pattern
     const headerMatch = headerLine.match(/^r(\d+)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*(.*)$/);
     
     if (headerMatch) {
@@ -330,7 +415,7 @@ export function parseLogOutput(output: string): SvnLogEntry[] {
           revision: parseInt(revision, 10),
           author: author.trim(),
           date: date.trim(),
-          message: message || 'Sin mensaje'
+          message: message || 'No message'
         });
       } catch (parseError) {
         console.warn(`Warning: Failed to parse log entry: ${parseError}`);
@@ -343,7 +428,52 @@ export function parseLogOutput(output: string): SvnLogEntry[] {
 }
 
 /**
- * Formatear duración en milisegundos a formato legible
+ * Parse output of `svn list`. Supports both simple and verbose modes.
+ * Simple: one name per line; directories end with '/'.
+ * Verbose: "REV AUTHOR [SIZE] DATE NAME" — size is absent for directories.
+ */
+export function parseListOutput(output: string, verbose: boolean = false): SvnListEntry[] {
+  const entries: SvnListEntry[] = [];
+  if (!output || output.trim().length === 0) {
+    return entries;
+  }
+
+  const lines = output.split('\n').map(l => l.replace(/\r$/, '')).filter(l => l.length > 0);
+
+  if (!verbose) {
+    for (const rawName of lines) {
+      const isDir = rawName.endsWith('/');
+      const name = isDir ? rawName.slice(0, -1) : rawName;
+      if (!name) continue;
+      entries.push({ name, kind: isDir ? 'dir' : 'file' });
+    }
+    return entries;
+  }
+
+  // Verbose: REV AUTHOR [SIZE] DATE... NAME
+  // SIZE only appears for files; DATE spans multiple tokens (month day year/time).
+  // Regex: 4 fixed tokens (rev, author, size-or-empty, date-block) + name.
+  const verboseRegex = /^\s*(\d+)\s+(\S+)\s+(?:(\d+)\s+)?(\S+\s+\S+\s+\S+)\s+(.+?)\s*$/;
+  for (const line of lines) {
+    const m = line.match(verboseRegex);
+    if (!m) continue;
+    const [, rev, author, size, date, rawName] = m;
+    const isDir = rawName.endsWith('/') || rawName === '.';
+    const name = isDir && rawName !== '.' ? rawName.slice(0, -1) : rawName;
+    entries.push({
+      name,
+      kind: isDir ? 'dir' : 'file',
+      revision: parseInt(rev, 10),
+      author,
+      size: size !== undefined ? parseInt(size, 10) : undefined,
+      date
+    });
+  }
+  return entries;
+}
+
+/**
+ * Format a duration in milliseconds to a human-readable string
  */
 export function formatDuration(milliseconds: number): string {
   if (milliseconds < 1000) {
@@ -361,54 +491,94 @@ export function formatDuration(milliseconds: number): string {
 }
 
 /**
- * Validar nombre de archivo/directorio
+ * Validate a file/directory name
  */
 export function validatePath(filePath: string): boolean {
-  // Verificar que no contenga caracteres prohibidos en Windows
-  // Pero permitir dos puntos en contextos válidos (drive letters en Windows)
-  
-  // Patrón para detectar rutas absolutas de Windows (C:, D:, etc.)
+  // Check that it does not contain characters forbidden on Windows
+  // but allow a colon in valid contexts (Windows drive letters)
+
+  // Pattern to detect Windows absolute paths (C:, D:, etc.)
   const windowsAbsolutePathPattern = /^[A-Za-z]:[\\\/]/;
-  
+
   if (windowsAbsolutePathPattern.test(filePath)) {
-    // Para rutas absolutas de Windows, verificar solo después del drive letter
-    const pathAfterDrive = filePath.substring(2); // Quitar "C:" o similar
+    // For Windows absolute paths, only validate the segment after the drive letter
+    const pathAfterDrive = filePath.substring(2); // Strip "C:" or similar
     const invalidChars = /[<>:"|?*]/;
     return !invalidChars.test(pathAfterDrive);
   } else {
-    // Para todas las demás rutas, aplicar validación completa
+    // For every other path, apply full validation
     const invalidChars = /[<>:"|?*]/;
     return !invalidChars.test(filePath);
   }
 }
 
 /**
- * Obtener rutas relativas desde el directorio de trabajo
+ * Get a relative path from the working directory
  */
 export function getRelativePath(fullPath: string, workingDirectory: string): string {
   return path.relative(workingDirectory, fullPath).replace(/\\/g, '/');
 }
 
 /**
- * Validar URL de repositorio SVN
+ * Validate an SVN repository URL. Recognises svn://, svn+<tunnel>://
+ * (e.g. svn+ssh://), http(s):// and file://.
  */
 export function validateSvnUrl(url: string): boolean {
-  const svnUrlPattern = /^(svn|https?|file):\/\/.+/i;
+  const svnUrlPattern = /^(svn(\+[a-z0-9]+)?|https?|file):\/\/.+/i;
   return svnUrlPattern.test(url);
 }
 
 /**
- * Limpiar y normalizar salida de comando
+ * Join a repository base URL with a repo-relative path. Preserves the
+ * exact encoding of the inputs — we do not re-encode callers' input.
+ */
+export function combineRepoUrl(baseUrl: string, repoPath: string): string {
+  const base = baseUrl.replace(/\/+$/, '');
+  const rel = repoPath.replace(/^\/+/, '').replace(/\/+$/, '');
+  return rel ? `${base}/${rel}` : base;
+}
+
+export interface SvnResolvedTarget {
+  /** Value passed to the svn CLI. */
+  value: string;
+  kind: 'url' | 'path';
+}
+
+/**
+ * Turn a user target into something svn can accept: absolute URL,
+ * repo-relative path (joined with SVN_URL), or normalized local path.
+ */
+export function resolveSvnTarget(target: string, config: SvnConfig): SvnResolvedTarget {
+  if (!target || typeof target !== 'string') {
+    throw new SvnError('Target is required');
+  }
+
+  if (validateSvnUrl(target)) {
+    return { value: target, kind: 'url' };
+  }
+
+  if (target.startsWith('/') && config.url) {
+    return { value: combineRepoUrl(config.url, target), kind: 'url' };
+  }
+
+  if (!validatePath(target)) {
+    throw new SvnError(`Invalid path or URL: ${target}`);
+  }
+  return { value: normalizePath(target), kind: 'path' };
+}
+
+/**
+ * Clean and normalize command output
  */
 export function cleanOutput(output: string): string {
   return output
-    .replace(/\r\n/g, '\n')  // Normalizar line endings
-    .replace(/\r/g, '\n')    // Convertir CR a LF
+    .replace(/\r\n/g, '\n')  // Normalize line endings
+    .replace(/\r/g, '\n')    // Convert CR to LF
     .trim();
 }
 
 /**
- * Crear mensaje de error SVN más descriptivo
+ * Create a more descriptive SVN error message
  */
 export function createSvnError(message: string, command?: string, stderr?: string): SvnError {
   const error = new SvnError(message);
@@ -418,31 +588,31 @@ export function createSvnError(message: string, command?: string, stderr?: strin
 }
 
 /**
- * Limpiar cache de credenciales SVN para resolver errores E215004
+ * Clear the SVN credentials cache to resolve E215004 errors
  */
 export async function clearSvnCredentials(config: SvnConfig): Promise<SvnResponse> {
   try {
-    // En sistemas Unix/Linux, SVN guarda credenciales en ~/.subversion/auth
-    // En Windows, en %APPDATA%\Subversion\auth
-    // Intentar limpiar usando el comando auth específico si está disponible
-    
-    // Primero intentar con el comando de limpieza estándar
+    // On Unix/Linux systems, SVN stores credentials in ~/.subversion/auth
+    // On Windows, in %APPDATA%\Subversion\auth
+    // Attempt to clear using the dedicated auth command if available
+
+    // First try the standard cleanup command
     return await executeSvnCommand(config, ['auth', '--remove'], { noAuthCache: true });
   } catch (error: any) {
-    // Si el comando auth no está disponible, intentar alternativa
+    // If the auth command is unavailable, try a fallback
     try {
-      // Como fallback, usar un comando que no guarde credenciales
+      // Fallback: run a command that does not store credentials
       const response = await executeSvnCommand(config, ['info', '--non-interactive'], { noAuthCache: true });
       return {
         success: true,
-        data: 'Cache de credenciales limpiado (usando método alternativo)',
+        data: 'Credentials cache cleared (using alternative method)',
         command: 'clear-credentials',
         workingDirectory: config.workingDirectory!
       };
     } catch (fallbackError: any) {
       return {
         success: false,
-        error: `No se pudo limpiar el cache de credenciales: ${fallbackError.message}`,
+        error: `Could not clear credentials cache: ${fallbackError.message}`,
         command: 'clear-credentials',
         workingDirectory: config.workingDirectory!
       };

--- a/config.example.env
+++ b/config.example.env
@@ -1,19 +1,27 @@
-# Configuración de SVN MCP Server
-# Copia este archivo como .env y configura tus valores
+# SVN MCP Server configuration
+# Copy this file as .env and set your values
 
-# Ruta al ejecutable de SVN (opcional)
-# Si no se especifica, se usa 'svn' desde PATH
+# Path to the SVN executable (optional)
+# If unset, 'svn' from PATH is used
 SVN_PATH=svn
 
-# Directorio de trabajo SVN
-# Debe ser un working copy válido de SVN
-SVN_WORKING_DIRECTORY=/path/to/your/svn/working/copy
+# Local SVN working directory (optional)
+# Must be a valid SVN working copy on the local filesystem. Required for
+# working-copy operations (status, commit, add, revert, update, ...).
+SVN_WORKING_DIRECTORY=C:/path/to/your/svn/working/copy
 
-# Credenciales de autenticación (opcional)
-# Solo necesario si el repositorio requiere autenticación
-SVN_USERNAME=tu_usuario
-SVN_PASSWORD=tu_contraseña
+# Repository URL (optional)
+# When set, targets starting with '/' are resolved against this URL, so
+# agents can pass '/trunk/path/to/file.sql' instead of a full URL.
+# Also enables URL-only workflows without a working copy.
+# Alias: SVN_REPOSITORY_URL
+SVN_URL=https://svn.example.com/your-repo
 
-# Timeout para comandos SVN en milisegundos (opcional)
-# Por defecto: 30000 (30 segundos)
-SVN_TIMEOUT=30000 
+# Authentication credentials (optional)
+# Only required if the repository requires authentication
+SVN_USERNAME=your_username
+SVN_PASSWORD=your_password
+
+# Timeout for SVN commands in milliseconds (optional)
+# Default: 30000 (30 seconds)
+SVN_TIMEOUT=30000

--- a/index.ts
+++ b/index.ts
@@ -30,28 +30,28 @@ function getSvnService(): SvnService {
   return svnService;
 }
 
-// ----- HERRAMIENTAS MCP PARA SUBVERSION (SVN) -----
+// ----- MCP TOOLS FOR SUBVERSION (SVN) -----
 
-// 1. Health Check del sistema SVN
+// 1. SVN system health check
 server.tool(
   "svn_health_check",
-  "Verificar el estado de salud del sistema SVN y working copy",
+  "Check SVN health and working-copy connectivity",
   {},
   async () => {
     try {
       const result = await getSvnService().healthCheck();
-      
+
       const data = result.data;
       const statusIcon = data?.svnAvailable ? '✅' : '❌';
       const wcIcon = data?.workingCopyValid ? '📁' : '📂';
       const repoIcon = data?.repositoryAccessible ? '🔗' : '🔌';
-      
-      const healthText = `${statusIcon} **Estado del Sistema SVN**\n\n` +
-        `**SVN Disponible:** ${data?.svnAvailable ? 'Sí' : 'No'}\n` +
-        `**Versión:** ${data?.version || 'N/A'}\n` +
-        `${wcIcon} **Working Copy Válido:** ${data?.workingCopyValid ? 'Sí' : 'No'}\n` +
-        `${repoIcon} **Repositorio Accesible:** ${data?.repositoryAccessible ? 'Sí' : 'No'}\n` +
-        `**Directorio de Trabajo:** ${result.workingDirectory}`;
+
+      const healthText = `${statusIcon} **SVN System Status**\n\n` +
+        `**SVN Available:** ${data?.svnAvailable ? 'Yes' : 'No'}\n` +
+        `**Version:** ${data?.version || 'N/A'}\n` +
+        `${wcIcon} **Working Copy Valid:** ${data?.workingCopyValid ? 'Yes' : 'No'}\n` +
+        `${repoIcon} **Repository Accessible:** ${data?.repositoryAccessible ? 'Yes' : 'No'}\n` +
+        `**Working Directory:** ${result.workingDirectory}`;
 
       return {
         content: [{ type: "text", text: healthText }],
@@ -64,40 +64,39 @@ server.tool(
   }
 );
 
-// 1.1. Diagnóstico avanzado de comandos SVN
+// 1.1. Advanced SVN command diagnostics
 server.tool(
   "svn_diagnose",
-  "Diagnosticar problemas específicos con comandos SVN",
+  "Run targeted diagnostics on common SVN command failures",
   {},
   async () => {
     try {
       const result = await getSvnService().diagnoseCommands();
       const data = result.data!;
-      
+
       const statusLocalIcon = data.statusLocal ? '✅' : '❌';
       const statusRemoteIcon = data.statusRemote ? '✅' : '❌';
       const logIcon = data.logBasic ? '✅' : '❌';
-      
-      let diagnosticText = `🔍 **Diagnóstico de Comandos SVN**\n\n` +
-        `**Directorio de Trabajo:** ${data.workingCopyPath}\n\n` +
-        `${statusLocalIcon} **Status Local:** ${data.statusLocal ? 'Funciona' : 'Falló'}\n` +
-        `${statusRemoteIcon} **Status Remoto:** ${data.statusRemote ? 'Funciona' : 'Falló'}\n` +
-        `${logIcon} **Log Básico:** ${data.logBasic ? 'Funciona' : 'Falló'}\n`;
-      
+
+      let diagnosticText = `🔍 **SVN Command Diagnostics**\n\n` +
+        `**Working Directory:** ${data.workingCopyPath}\n\n` +
+        `${statusLocalIcon} **Local Status:** ${data.statusLocal ? 'Working' : 'Failed'}\n` +
+        `${statusRemoteIcon} **Remote Status:** ${data.statusRemote ? 'Working' : 'Failed'}\n` +
+        `${logIcon} **Basic Log:** ${data.logBasic ? 'Working' : 'Failed'}\n`;
+
       if (data.errors.length > 0) {
-        diagnosticText += `\n**Errores Detectados:**\n`;
+        diagnosticText += `\n**Detected Errors:**\n`;
         data.errors.forEach((error, index) => {
           diagnosticText += `${index + 1}. ${error}\n`;
         });
       }
-      
-      // Añadir sugerencias basadas en los errores
+
       if (!data.statusRemote || !data.logBasic) {
-        diagnosticText += `\n**Posibles Soluciones:**\n`;
-        diagnosticText += `• Verificar conexión a internet\n`;
-        diagnosticText += `• Verificar credenciales de SVN\n`;
-        diagnosticText += `• Ejecutar 'svn cleanup' si hay problemas de lock\n`;
-        diagnosticText += `• Verificar que el working copy esté actualizado\n`;
+        diagnosticText += `\n**Possible Solutions:**\n`;
+        diagnosticText += `• Check internet connectivity\n`;
+        diagnosticText += `• Verify SVN credentials\n`;
+        diagnosticText += `• Run 'svn cleanup' if there are lock issues\n`;
+        diagnosticText += `• Make sure the working copy is up to date\n`;
       }
 
       return {
@@ -105,37 +104,37 @@ server.tool(
       };
     } catch (error: any) {
       return {
-        content: [{ type: "text", text: `❌ **Error en diagnóstico:** ${error.message}` }],
+        content: [{ type: "text", text: `❌ **Diagnostic Error:** ${error.message}` }],
       };
     }
   }
 );
 
-// 2. Obtener información del repositorio
+// 2. Get repository information
 server.tool(
   "svn_info",
-  "Obtener información detallada del working copy o archivo específico",
+  "Get detailed information about the working copy or a specific file. The path may be a local path, a repository URL, or a repo-relative path starting with '/' (joined with SVN_URL when configured).",
   {
-    path: z.string().optional().describe("Ruta específica a consultar (opcional)")
+    path: z.string().optional().describe("Local path, full URL, or repo-relative path like '/trunk/foo'")
   },
   async (args) => {
     try {
       const result = await getSvnService().getInfo(args.path);
       const info = result.data!;
-      
-      const infoText = `📋 **Información SVN**\n\n` +
-        `**Ruta:** ${info.path}\n` +
+
+      const infoText = `📋 **SVN Info**\n\n` +
+        `**Path:** ${info.path}\n` +
         `**URL:** ${info.url}\n` +
-        `**URL Relativa:** ${info.relativeUrl}\n` +
-        `**Raíz del Repositorio:** ${info.repositoryRoot}\n` +
+        `**Relative URL:** ${info.relativeUrl}\n` +
+        `**Repository Root:** ${info.repositoryRoot}\n` +
         `**UUID:** ${info.repositoryUuid}\n` +
-        `**Revisión:** ${info.revision}\n` +
-        `**Tipo de Nodo:** ${info.nodeKind}\n` +
-        `**Último Autor:** ${info.lastChangedAuthor}\n` +
-        `**Última Revisión:** ${info.lastChangedRev}\n` +
-        `**Última Fecha:** ${info.lastChangedDate}\n` +
-        `**Raíz Working Copy:** ${info.workingCopyRootPath}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}`;
+        `**Revision:** ${info.revision}\n` +
+        `**Node Kind:** ${info.nodeKind}\n` +
+        `**Last Author:** ${info.lastChangedAuthor}\n` +
+        `**Last Changed Revision:** ${info.lastChangedRev}\n` +
+        `**Last Changed Date:** ${info.lastChangedDate}\n` +
+        `**Working Copy Root:** ${info.workingCopyRootPath}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}`;
 
       return {
         content: [{ type: "text", text: infoText }],
@@ -148,50 +147,50 @@ server.tool(
   }
 );
 
-// 3. Obtener estado de archivos
+// 3. Get file status
 server.tool(
   "svn_status",
-  "Ver el estado de archivos en el working copy",
+  "Show the status of files in the working copy",
   {
-    path: z.string().optional().describe("Ruta específica a consultar"),
-    showAll: z.boolean().optional().default(false).describe("Mostrar estado remoto también")
+    path: z.string().optional().describe("Specific path to query"),
+    showAll: z.boolean().optional().default(false).describe("Also show remote status")
   },
   async (args) => {
     try {
       const result = await getSvnService().getStatus(args.path, args.showAll);
       const statusList = result.data!;
-      
+
       if (statusList.length === 0) {
         return {
-          content: [{ type: "text", text: "✅ **No hay cambios en el working copy**" }],
+          content: [{ type: "text", text: "✅ **No changes in the working copy**" }],
         };
       }
 
-             const statusText = `📊 **Estado SVN** (${statusList.length} elementos)\n\n` +
-         statusList.map(status => {
-           const statusIcon: {[key: string]: string} = {
-             'added': '➕',
-             'deleted': '➖',
-             'modified': '✏️',
-             'replaced': '🔄',
-             'merged': '🔀',
-             'conflicted': '⚠️',
-             'ignored': '🙈',
-             'none': '⚪',
-             'normal': '✅',
-             'external': '🔗',
-             'incomplete': '⏸️',
-             'unversioned': '❓',
-             'missing': '❌'
-           };
-           
-           return `${statusIcon[status.status] || '📄'} **${status.status.toUpperCase()}** - ${status.path}`;
-         }).join('\n') +
-         `\n\n**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}`;
+      const statusText = `📊 **SVN Status** (${statusList.length} items)\n\n` +
+        statusList.map(status => {
+          const statusIcon: {[key: string]: string} = {
+            'added': '➕',
+            'deleted': '➖',
+            'modified': '✏️',
+            'replaced': '🔄',
+            'merged': '🔀',
+            'conflicted': '⚠️',
+            'ignored': '🙈',
+            'none': '⚪',
+            'normal': '✅',
+            'external': '🔗',
+            'incomplete': '⏸️',
+            'unversioned': '❓',
+            'missing': '❌'
+          };
 
-       return {
-         content: [{ type: "text", text: statusText }],
-       };
+          return `${statusIcon[status.status] || '📄'} **${status.status.toUpperCase()}** - ${status.path}`;
+        }).join('\n') +
+        `\n\n**Execution Time:** ${formatDuration(result.executionTime || 0)}`;
+
+      return {
+        content: [{ type: "text", text: statusText }],
+      };
     } catch (error: any) {
       return {
         content: [{ type: "text", text: `❌ **Error:** ${error.message}` }],
@@ -200,35 +199,35 @@ server.tool(
   }
 );
 
-// 4. Obtener historial de cambios
+// 4. Get change history
 server.tool(
   "svn_log",
-  "Ver historial de commits del repositorio",
+  "Show the commit history of the repository. The path may be a local path, a repository URL, or a repo-relative path starting with '/' (joined with SVN_URL when configured).",
   {
-    path: z.string().optional().describe("Ruta específica"),
-    limit: z.number().optional().default(10).describe("Número máximo de entradas"),
-    revision: z.string().optional().describe("Revisión específica o rango (ej: 100:200)")
+    path: z.string().optional().describe("Local path, full URL, or repo-relative path like '/trunk/foo'"),
+    limit: z.number().optional().default(10).describe("Maximum number of entries"),
+    revision: z.string().optional().describe("Specific revision or range (e.g. 100:200)")
   },
   async (args) => {
     try {
       const result = await getSvnService().getLog(args.path, args.limit, args.revision);
       const logEntries = result.data!;
-      
+
       if (logEntries.length === 0) {
         return {
-          content: [{ type: "text", text: "📝 **No se encontraron entradas en el log**" }],
+          content: [{ type: "text", text: "📝 **No log entries found**" }],
         };
       }
 
-      const logText = `📚 **Historial SVN** (${logEntries.length} entradas)\n\n` +
-        logEntries.map((entry, index) => 
-          `**${index + 1}. Revisión ${entry.revision}**\n` +
-          `👤 **Autor:** ${entry.author}\n` +
-          `📅 **Fecha:** ${entry.date}\n` +
-          `💬 **Mensaje:** ${entry.message || 'Sin mensaje'}\n` +
+      const logText = `📚 **SVN History** (${logEntries.length} entries)\n\n` +
+        logEntries.map((entry, index) =>
+          `**${index + 1}. Revision ${entry.revision}**\n` +
+          `👤 **Author:** ${entry.author}\n` +
+          `📅 **Date:** ${entry.date}\n` +
+          `💬 **Message:** ${entry.message || 'No message'}\n` +
           `---`
         ).join('\n\n') +
-        `\n**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}`;
+        `\n**Execution Time:** ${formatDuration(result.executionTime || 0)}`;
 
       return {
         content: [{ type: "text", text: logText }],
@@ -241,29 +240,29 @@ server.tool(
   }
 );
 
-// 5. Ver diferencias
+// 5. View differences
 server.tool(
   "svn_diff",
-  "Ver diferencias entre versiones de archivos",
+  "Show differences between file revisions. The path may be a local path, a repository URL, or a repo-relative path starting with '/' (joined with SVN_URL when configured).",
   {
-    path: z.string().optional().describe("Ruta específica"),
-    oldRevision: z.string().optional().describe("Revisión antigua"),
-    newRevision: z.string().optional().describe("Revisión nueva")
+    path: z.string().optional().describe("Local path, full URL, or repo-relative path like '/trunk/foo'"),
+    oldRevision: z.string().optional().describe("Old revision"),
+    newRevision: z.string().optional().describe("New revision")
   },
   async (args) => {
     try {
       const result = await getSvnService().getDiff(args.path, args.oldRevision, args.newRevision);
       const diffOutput = result.data!;
-      
+
       if (!diffOutput || diffOutput.trim().length === 0) {
         return {
-          content: [{ type: "text", text: "✅ **No hay diferencias encontradas**" }],
+          content: [{ type: "text", text: "✅ **No differences found**" }],
         };
       }
 
-      const diffText = `🔍 **Diferencias SVN**\n\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
+      const diffText = `🔍 **SVN Diff**\n\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
         `\`\`\`diff\n${diffOutput}\n\`\`\``;
 
       return {
@@ -277,17 +276,17 @@ server.tool(
   }
 );
 
-// 6. Checkout de repositorio
+// 6. Repository checkout
 server.tool(
   "svn_checkout",
-  "Hacer checkout de un repositorio SVN",
+  "Check out an SVN repository",
   {
-    url: z.string().describe("URL del repositorio SVN"),
-    path: z.string().optional().describe("Directorio destino"),
-    revision: z.union([z.number(), z.literal("HEAD")]).optional().describe("Revisión específica"),
-    depth: z.enum(["empty", "files", "immediates", "infinity"]).optional().describe("Profundidad del checkout"),
-    force: z.boolean().optional().default(false).describe("Forzar checkout"),
-    ignoreExternals: z.boolean().optional().default(false).describe("Ignorar externals")
+    url: z.string().describe("SVN repository URL"),
+    path: z.string().optional().describe("Destination directory"),
+    revision: z.union([z.number(), z.literal("HEAD")]).optional().describe("Specific revision"),
+    depth: z.enum(["empty", "files", "immediates", "infinity"]).optional().describe("Checkout depth"),
+    force: z.boolean().optional().default(false).describe("Force checkout"),
+    ignoreExternals: z.boolean().optional().default(false).describe("Ignore externals")
   },
   async (args) => {
     try {
@@ -297,15 +296,15 @@ server.tool(
         force: args.force,
         ignoreExternals: args.ignoreExternals
       };
-      
+
       const result = await getSvnService().checkout(args.url, args.path, options);
-      
-      const checkoutText = `📥 **Checkout Completado**\n\n` +
+
+      const checkoutText = `📥 **Checkout Completed**\n\n` +
         `**URL:** ${args.url}\n` +
-        `**Destino:** ${args.path || 'Directorio actual'}\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
-        `**Resultado:**\n\`\`\`\n${result.data}\n\`\`\``;
+        `**Destination:** ${args.path || 'Current directory'}\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        `**Output:**\n\`\`\`\n${result.data}\n\`\`\``;
 
       return {
         content: [{ type: "text", text: checkoutText }],
@@ -318,16 +317,16 @@ server.tool(
   }
 );
 
-// 7. Actualizar working copy
+// 7. Update working copy
 server.tool(
   "svn_update",
-  "Actualizar working copy desde el repositorio",
+  "Update the working copy from the repository",
   {
-    path: z.string().optional().describe("Ruta específica a actualizar"),
-    revision: z.union([z.number(), z.literal("HEAD"), z.literal("BASE"), z.literal("COMMITTED"), z.literal("PREV")]).optional().describe("Revisión objetivo"),
-    force: z.boolean().optional().default(false).describe("Forzar actualización"),
-    ignoreExternals: z.boolean().optional().default(false).describe("Ignorar externals"),
-    acceptConflicts: z.enum(["postpone", "base", "mine-conflict", "theirs-conflict", "mine-full", "theirs-full"]).optional().describe("Como manejar conflictos")
+    path: z.string().optional().describe("Specific path to update"),
+    revision: z.union([z.number(), z.literal("HEAD"), z.literal("BASE"), z.literal("COMMITTED"), z.literal("PREV")]).optional().describe("Target revision"),
+    force: z.boolean().optional().default(false).describe("Force update"),
+    ignoreExternals: z.boolean().optional().default(false).describe("Ignore externals"),
+    acceptConflicts: z.enum(["postpone", "base", "mine-conflict", "theirs-conflict", "mine-full", "theirs-full"]).optional().describe("How to handle conflicts")
   },
   async (args) => {
     try {
@@ -337,14 +336,14 @@ server.tool(
         ignoreExternals: args.ignoreExternals,
         acceptConflicts: args.acceptConflicts
       };
-      
+
       const result = await getSvnService().update(args.path, options);
-      
-      const updateText = `🔄 **Actualización Completada**\n\n` +
-        `**Ruta:** ${args.path || 'Directorio actual'}\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
-        `**Resultado:**\n\`\`\`\n${result.data}\n\`\`\``;
+
+      const updateText = `🔄 **Update Completed**\n\n` +
+        `**Path:** ${args.path || 'Current directory'}\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        `**Output:**\n\`\`\`\n${result.data}\n\`\`\``;
 
       return {
         content: [{ type: "text", text: updateText }],
@@ -357,17 +356,17 @@ server.tool(
   }
 );
 
-// 8. Añadir archivos
+// 8. Add files
 server.tool(
   "svn_add",
-  "Añadir archivos al control de versiones",
+  "Add files to version control",
   {
-    paths: z.union([z.string(), z.array(z.string())]).describe("Archivo(s) o directorio(s) a añadir"),
-    force: z.boolean().optional().default(false).describe("Forzar adición"),
-    noIgnore: z.boolean().optional().default(false).describe("No respetar reglas de ignore"),
-    parents: z.boolean().optional().default(false).describe("Crear directorios padre si es necesario"),
-    autoProps: z.boolean().optional().describe("Aplicar auto-propiedades"),
-    noAutoProps: z.boolean().optional().describe("No aplicar auto-propiedades")
+    paths: z.union([z.string(), z.array(z.string())]).describe("File(s) or director(y|ies) to add"),
+    force: z.boolean().optional().default(false).describe("Force addition"),
+    noIgnore: z.boolean().optional().default(false).describe("Do not honor ignore rules"),
+    parents: z.boolean().optional().default(false).describe("Create parent directories if needed"),
+    autoProps: z.boolean().optional().describe("Apply auto-props"),
+    noAutoProps: z.boolean().optional().describe("Do not apply auto-props")
   },
   async (args) => {
     try {
@@ -378,15 +377,15 @@ server.tool(
         autoProps: args.autoProps,
         noAutoProps: args.noAutoProps
       };
-      
+
       const result = await getSvnService().add(args.paths, options);
       const pathsArray = Array.isArray(args.paths) ? args.paths : [args.paths];
-      
-      const addText = `➕ **Archivos Añadidos**\n\n` +
-        `**Archivos:** ${pathsArray.join(', ')}\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
-        `**Resultado:**\n\`\`\`\n${result.data}\n\`\`\``;
+
+      const addText = `➕ **Files Added**\n\n` +
+        `**Files:** ${pathsArray.join(', ')}\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        `**Output:**\n\`\`\`\n${result.data}\n\`\`\``;
 
       return {
         content: [{ type: "text", text: addText }],
@@ -399,17 +398,17 @@ server.tool(
   }
 );
 
-// 9. Commit de cambios
+// 9. Commit changes
 server.tool(
   "svn_commit",
-  "Confirmar cambios al repositorio",
+  "Commit changes to the repository",
   {
-    message: z.string().describe("Mensaje del commit"),
-    paths: z.array(z.string()).optional().describe("Archivos específicos a confirmar"),
-    file: z.string().optional().describe("Archivo con mensaje de commit"),
-    force: z.boolean().optional().default(false).describe("Forzar commit"),
-    keepLocks: z.boolean().optional().default(false).describe("Mantener locks después del commit"),
-    noUnlock: z.boolean().optional().default(false).describe("No desbloquear archivos")
+    message: z.string().describe("Commit message"),
+    paths: z.array(z.string()).optional().describe("Specific files to commit"),
+    file: z.string().optional().describe("File containing the commit message"),
+    force: z.boolean().optional().default(false).describe("Force commit"),
+    keepLocks: z.boolean().optional().default(false).describe("Keep locks after commit"),
+    noUnlock: z.boolean().optional().default(false).describe("Do not unlock files")
   },
   async (args) => {
     try {
@@ -420,15 +419,15 @@ server.tool(
         keepLocks: args.keepLocks,
         noUnlock: args.noUnlock
       };
-      
+
       const result = await getSvnService().commit(options, args.paths);
-      
-      const commitText = `✅ **Commit Realizado**\n\n` +
-        `**Mensaje:** ${args.message}\n` +
-        `**Archivos:** ${args.paths?.join(', ') || 'Todos los cambios'}\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
-        `**Resultado:**\n\`\`\`\n${result.data}\n\`\`\``;
+
+      const commitText = `✅ **Commit Completed**\n\n` +
+        `**Message:** ${args.message}\n` +
+        `**Files:** ${args.paths?.join(', ') || 'All changes'}\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        `**Output:**\n\`\`\`\n${result.data}\n\`\`\``;
 
       return {
         content: [{ type: "text", text: commitText }],
@@ -441,15 +440,15 @@ server.tool(
   }
 );
 
-// 10. Eliminar archivos
+// 10. Delete files
 server.tool(
   "svn_delete",
-  "Eliminar archivos del control de versiones",
+  "Remove files from version control",
   {
-    paths: z.union([z.string(), z.array(z.string())]).describe("Archivo(s) o directorio(s) a eliminar"),
-    message: z.string().optional().describe("Mensaje para eliminación directa en repositorio"),
-    force: z.boolean().optional().default(false).describe("Forzar eliminación"),
-    keepLocal: z.boolean().optional().default(false).describe("Mantener copia local")
+    paths: z.union([z.string(), z.array(z.string())]).describe("File(s) or director(y|ies) to delete"),
+    message: z.string().optional().describe("Message for direct repository deletion"),
+    force: z.boolean().optional().default(false).describe("Force deletion"),
+    keepLocal: z.boolean().optional().default(false).describe("Keep local copy")
   },
   async (args) => {
     try {
@@ -458,16 +457,16 @@ server.tool(
         force: args.force,
         keepLocal: args.keepLocal
       };
-      
+
       const result = await getSvnService().delete(args.paths, options);
       const pathsArray = Array.isArray(args.paths) ? args.paths : [args.paths];
-      
-      const deleteText = `🗑️ **Archivos Eliminados**\n\n` +
-        `**Archivos:** ${pathsArray.join(', ')}\n` +
-        `**Mantener Local:** ${args.keepLocal ? 'Sí' : 'No'}\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
-        `**Resultado:**\n\`\`\`\n${result.data}\n\`\`\``;
+
+      const deleteText = `🗑️ **Files Deleted**\n\n` +
+        `**Files:** ${pathsArray.join(', ')}\n` +
+        `**Keep Local:** ${args.keepLocal ? 'Yes' : 'No'}\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        `**Output:**\n\`\`\`\n${result.data}\n\`\`\``;
 
       return {
         content: [{ type: "text", text: deleteText }],
@@ -480,23 +479,23 @@ server.tool(
   }
 );
 
-// 11. Revertir cambios
+// 11. Revert changes
 server.tool(
   "svn_revert",
-  "Revertir cambios locales en archivos",
+  "Revert local changes on files",
   {
-    paths: z.union([z.string(), z.array(z.string())]).describe("Archivo(s) o directorio(s) a revertir")
+    paths: z.union([z.string(), z.array(z.string())]).describe("File(s) or director(y|ies) to revert")
   },
   async (args) => {
     try {
       const result = await getSvnService().revert(args.paths);
       const pathsArray = Array.isArray(args.paths) ? args.paths : [args.paths];
-      
-      const revertText = `↩️ **Cambios Revertidos**\n\n` +
-        `**Archivos:** ${pathsArray.join(', ')}\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
-        `**Resultado:**\n\`\`\`\n${result.data}\n\`\`\``;
+
+      const revertText = `↩️ **Changes Reverted**\n\n` +
+        `**Files:** ${pathsArray.join(', ')}\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        `**Output:**\n\`\`\`\n${result.data}\n\`\`\``;
 
       return {
         content: [{ type: "text", text: revertText }],
@@ -509,22 +508,22 @@ server.tool(
   }
 );
 
-// 12. Limpiar working copy
+// 12. Clean up working copy
 server.tool(
   "svn_cleanup",
-  "Limpiar working copy de operaciones interrumpidas",
+  "Clean up the working copy from interrupted operations",
   {
-    path: z.string().optional().describe("Ruta específica a limpiar")
+    path: z.string().optional().describe("Specific path to clean up")
   },
   async (args) => {
     try {
       const result = await getSvnService().cleanup(args.path);
-      
-      const cleanupText = `🧹 **Cleanup Completado**\n\n` +
-        `**Ruta:** ${args.path || 'Directorio actual'}\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
-        `**Resultado:**\n\`\`\`\n${result.data}\n\`\`\``;
+
+      const cleanupText = `🧹 **Cleanup Completed**\n\n` +
+        `**Path:** ${args.path || 'Current directory'}\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        `**Output:**\n\`\`\`\n${result.data}\n\`\`\``;
 
       return {
         content: [{ type: "text", text: cleanupText }],
@@ -537,22 +536,128 @@ server.tool(
   }
 );
 
-// 13. Limpiar cache de credenciales SVN (para resolver errores E215004)
+// 13. Show the contents of a versioned file (svn cat)
+server.tool(
+  "svn_cat",
+  "Read a versioned file from the repository (local path, URL, or repo-relative path like '/trunk/foo.sql')",
+  {
+    target: z.string().describe("Local path, full URL, or repo-relative path like '/trunk/foo.sql'"),
+    revision: z.union([
+      z.number(),
+      z.literal("HEAD"),
+      z.literal("BASE"),
+      z.literal("COMMITTED"),
+      z.literal("PREV"),
+      z.string()
+    ]).optional().describe("Revision to query (defaults to HEAD/BASE depending on context)")
+  },
+  async (args) => {
+    try {
+      const result = await getSvnService().cat(args.target, { revision: args.revision });
+      const content = result.data ?? '';
+
+      const revisionLabel = args.revision !== undefined ? String(args.revision) : 'HEAD/BASE';
+      const header = `📄 **Contents of ${args.target}** (revision: ${revisionLabel})\n\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n`;
+
+      if (!content) {
+        return {
+          content: [{ type: "text", text: header + "*(empty file)*" }],
+        };
+      }
+
+      return {
+        content: [{ type: "text", text: header + `\`\`\`\n${content}\n\`\`\`` }],
+      };
+    } catch (error: any) {
+      return {
+        content: [{ type: "text", text: `❌ **Error:** ${error.message}` }],
+      };
+    }
+  }
+);
+
+// 14. List entries of a versioned directory (svn list)
+server.tool(
+  "svn_list",
+  "Browse a versioned directory (local path, URL, or repo-relative path; defaults to the working copy)",
+  {
+    target: z.string().optional().describe("Local path, full URL, or repo-relative path like '/tags' (defaults to working copy)"),
+    revision: z.union([
+      z.number(),
+      z.literal("HEAD"),
+      z.literal("BASE"),
+      z.literal("COMMITTED"),
+      z.literal("PREV"),
+      z.string()
+    ]).optional().describe("Revision to query"),
+    verbose: z.boolean().optional().default(false).describe("Include revision, author, size and date"),
+    recursive: z.boolean().optional().default(false).describe("List recursively"),
+    depth: z.enum(["empty", "files", "immediates", "infinity"]).optional().describe("Listing depth"),
+    includeExternals: z.boolean().optional().default(false).describe("Include externals")
+  },
+  async (args) => {
+    try {
+      const result = await getSvnService().list(args.target, {
+        revision: args.revision,
+        verbose: args.verbose,
+        recursive: args.recursive,
+        depth: args.depth,
+        includeExternals: args.includeExternals
+      });
+
+      const { entries, raw } = result.data!;
+      const targetLabel = args.target || 'working copy';
+
+      if (entries.length === 0) {
+        return {
+          content: [{ type: "text", text: `📂 **SVN Listing** (${targetLabel})\n\n*(no entries)*\n\n**Execution Time:** ${formatDuration(result.executionTime || 0)}` }],
+        };
+      }
+
+      const rows = entries.map(e => {
+        const icon = e.kind === 'dir' ? '📁' : '📄';
+        if (args.verbose) {
+          const size = e.size !== undefined ? `${e.size} B` : '-';
+          return `${icon} ${e.name}  (r${e.revision ?? '?'}, ${e.author ?? '?'}, ${size}, ${e.date ?? '?'})`;
+        }
+        return `${icon} ${e.name}`;
+      }).join('\n');
+
+      const listText = `📂 **SVN Listing** (${targetLabel}) — ${entries.length} entries\n\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        rows +
+        (args.verbose ? `\n\n<details><summary>Raw output</summary>\n\n\`\`\`\n${raw}\n\`\`\`\n</details>` : '');
+
+      return {
+        content: [{ type: "text", text: listText }],
+      };
+    } catch (error: any) {
+      return {
+        content: [{ type: "text", text: `❌ **Error:** ${error.message}` }],
+      };
+    }
+  }
+);
+
+// 15. Clear SVN credentials cache (to resolve E215004 errors)
 server.tool(
   "svn_clear_credentials",
-  "Limpiar cache de credenciales SVN para resolver errores de autenticación",
+  "Clear the SVN credentials cache to resolve authentication errors",
   {},
   async () => {
     try {
       const result = await getSvnService().clearCredentials();
-      
-      const clearText = `🔐 **Cache de Credenciales Limpiado**\n\n` +
-        `**Comando:** ${result.command}\n` +
-        `**Tiempo de Ejecución:** ${formatDuration(result.executionTime || 0)}\n\n` +
-        `**Resultado:**\n\`\`\`\n${result.data}\n\`\`\`\n\n` +
-        `**Nota:** Esto puede ayudar a resolver errores como:\n` +
+
+      const clearText = `🔐 **Credentials Cache Cleared**\n\n` +
+        `**Command:** ${result.command}\n` +
+        `**Execution Time:** ${formatDuration(result.executionTime || 0)}\n\n` +
+        `**Output:**\n\`\`\`\n${result.data}\n\`\`\`\n\n` +
+        `**Note:** This can help resolve errors such as:\n` +
         `• E215004: No more credentials or we tried too many times\n` +
-        `• Errores de autenticación por credenciales cacheadas incorrectamente`;
+        `• Authentication errors due to incorrectly cached credentials`;
 
       return {
         content: [{ type: "text", text: clearText }],
@@ -570,38 +675,45 @@ async function runServer() {
     console.error("Creating SVN MCP Server...");
     console.error("Server info: svn-mcp-server");
     console.error("Version:", VERSION);
-    
+
     // Validate environment variables
     if (!process.env.SVN_PATH) {
       console.error("Info: SVN_PATH environment variable not set, using 'svn' from PATH");
     } else {
       console.error("SVN_PATH:", process.env.SVN_PATH);
     }
-    
+
     if (!process.env.SVN_WORKING_DIRECTORY) {
       console.error("Info: SVN_WORKING_DIRECTORY not set, using current directory");
     } else {
       console.error("SVN_WORKING_DIRECTORY:", process.env.SVN_WORKING_DIRECTORY);
     }
-    
+
+    const urlEnv = process.env.SVN_URL || process.env.SVN_REPOSITORY_URL;
+    if (urlEnv) {
+      console.error("SVN_URL:", urlEnv);
+    } else {
+      console.error("Info: SVN_URL not set — repo-relative targets (e.g. '/trunk/...') will be treated as local paths");
+    }
+
     if (process.env.SVN_USERNAME) {
       console.error("SVN_USERNAME:", process.env.SVN_USERNAME);
     }
-    
+
     if (process.env.SVN_PASSWORD) {
       console.error("SVN_PASSWORD:", "***");
     }
-    
+
     console.error("Starting SVN MCP Server in stdio mode...");
-    
+
     // Create transport
     const transport = new StdioServerTransport();
-    
+
     console.error("Connecting server to transport...");
-    
+
     // Connect server to transport - this should keep the process alive
     await server.connect(transport);
-    
+
     console.error("MCP Server connected and ready!");
     console.error("Available tools:", [
       "svn_health_check",
@@ -617,9 +729,11 @@ async function runServer() {
       "svn_delete",
       "svn_revert",
       "svn_cleanup",
+      "svn_cat",
+      "svn_list",
       "svn_clear_credentials"
     ]);
-    
+
   } catch (error) {
     console.error("Error starting server:", error);
     console.error("Stack trace:", (error as Error).stack);
@@ -628,4 +742,4 @@ async function runServer() {
 }
 
 // Start the server
-runServer(); 
+runServer();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@modelcontextprotocol/sdk": "1.6.1",
         "@types/node": "^22",
         "iconv-lite": "^0.7.0",
-        "jschardet": "^3.1.4",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.23.5"
       },
@@ -23,6 +22,7 @@
         "@jest/globals": "^29.7.0",
         "@types/jest": "^29.5.14",
         "jest": "^29.7.0",
+        "jschardet": "^3.1.4",
         "shx": "^0.3.4",
         "ts-jest": "^29.2.6",
         "typescript": "^5.6.2"
@@ -3285,6 +3285,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.1.4.tgz",
       "integrity": "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==",
+      "dev": true,
       "license": "LGPL-2.1+",
       "engines": {
         "node": ">=0.1.90"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grec0/mcp-svn",
   "version": "0.1.4",
-  "description": "MCP server para integración completa con Subversion (SVN)",
+  "description": "MCP server for full Subversion (SVN) integration",
   "license": "MIT",
   "author": "@grec0",
   "homepage": "https://github.com/gcorroto/mcp-svn",

--- a/run-mcp.bat
+++ b/run-mcp.bat
@@ -1,27 +1,27 @@
 @echo off
 echo Starting SVN MCP Server...
 
-REM Verificar si Node.js está disponible
+REM Check whether Node.js is available
 node --version >nul 2>&1
 if %errorlevel% neq 0 (
-    echo Error: Node.js no está instalado o no está en PATH
+    echo Error: Node.js is not installed or not in PATH
     pause
     exit /b 1
 )
 
-REM Verificar si el proyecto está compilado
+REM Check whether the project has been built
 if not exist "dist\index.js" (
-    echo Compilando el proyecto...
+    echo Building the project...
     npm run build
     if %errorlevel% neq 0 (
-        echo Error: Falló la compilación
+        echo Error: Build failed
         pause
         exit /b 1
     )
 )
 
-REM Ejecutar el servidor MCP
-echo Ejecutando SVN MCP Server...
+REM Run the MCP server
+echo Running SVN MCP Server...
 node dist\index.js
 
-pause 
+pause

--- a/run-mcp.sh
+++ b/run-mcp.sh
@@ -2,22 +2,22 @@
 
 echo "Starting SVN MCP Server..."
 
-# Verificar si Node.js está disponible
+# Check whether Node.js is available
 if ! command -v node &> /dev/null; then
-    echo "Error: Node.js no está instalado o no está en PATH"
+    echo "Error: Node.js is not installed or not in PATH"
     exit 1
 fi
 
-# Verificar si el proyecto está compilado
+# Check whether the project has been built
 if [ ! -f "dist/index.js" ]; then
-    echo "Compilando el proyecto..."
+    echo "Building the project..."
     npm run build
     if [ $? -ne 0 ]; then
-        echo "Error: Falló la compilación"
+        echo "Error: Build failed"
         exit 1
     fi
 fi
 
-# Ejecutar el servidor MCP
-echo "Ejecutando SVN MCP Server..."
-node dist/index.js 
+# Run the MCP server
+echo "Running SVN MCP Server..."
+node dist/index.js

--- a/tests/auth-error-e215004.test.ts
+++ b/tests/auth-error-e215004.test.ts
@@ -23,9 +23,9 @@ describe('E215004 Authentication Error Handling', () => {
       const service = svnService as any;
       const result = service.categorizeError(mockError, 'test command');
 
-      expect(result.message).toContain('Demasiados intentos de autenticación fallidos');
-      expect(result.suggestion).toContain('Limpia el cache de credenciales SVN');
-      expect(result.suggestion).toContain('SVN_USERNAME y SVN_PASSWORD');
+      expect(result.message).toContain('Too many failed authentication attempts');
+      expect(result.suggestion).toContain('Clear the SVN credentials cache');
+      expect(result.suggestion).toContain('SVN_USERNAME and SVN_PASSWORD');
     });
 
     it('should detect "No more credentials" text and provide specific guidance', () => {
@@ -37,8 +37,8 @@ describe('E215004 Authentication Error Handling', () => {
       const service = svnService as any;
       const result = service.categorizeError(mockError, 'test command');
 
-      expect(result.message).toContain('Demasiados intentos de autenticación fallidos');
-      expect(result.suggestion).toContain('Limpia el cache de credenciales SVN');
+      expect(result.message).toContain('Too many failed authentication attempts');
+      expect(result.suggestion).toContain('Clear the SVN credentials cache');
     });
 
     it('should detect "we tried too many times" text and provide specific guidance', () => {
@@ -50,8 +50,8 @@ describe('E215004 Authentication Error Handling', () => {
       const service = svnService as any;
       const result = service.categorizeError(mockError, 'test command');
 
-      expect(result.message).toContain('Demasiados intentos de autenticación fallidos');
-      expect(result.suggestion).toContain('Limpia el cache de credenciales SVN');
+      expect(result.message).toContain('Too many failed authentication attempts');
+      expect(result.suggestion).toContain('Clear the SVN credentials cache');
     });
 
     it('should still handle generic authentication errors', () => {
@@ -63,9 +63,9 @@ describe('E215004 Authentication Error Handling', () => {
       const service = svnService as any;
       const result = service.categorizeError(mockError, 'test command');
 
-      expect(result.message).toContain('Error de autenticación');
-      expect(result.suggestion).toContain('Verifica tus credenciales SVN');
-      expect(result.suggestion).not.toContain('Limpia el cache');
+      expect(result.message).toContain('Authentication error');
+      expect(result.suggestion).toContain('Verify your SVN credentials');
+      expect(result.suggestion).not.toContain('Clear the SVN credentials cache');
     });
   });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -14,7 +14,7 @@ describe('SVN MCP Integration Tests', () => {
 
   describe('SVN Installation', () => {
     it('should detect if SVN is available', async () => {
-      // Este test no falla si SVN no está disponible, solo reporta el estado
+      // This test does not fail when SVN is unavailable, it only reports the status
       console.log(`SVN Available: ${svnAvailable}`);
       expect(typeof svnAvailable).toBe('boolean');
     });
@@ -28,7 +28,7 @@ describe('SVN MCP Integration Tests', () => {
       expect(result.workingDirectory).toBeDefined();
       expect(typeof result.success).toBe('boolean');
       
-      // El comando puede ser 'health-check' si SVN está disponible o 'svn --version' si no lo está
+      // The command is 'health-check' when SVN is available or 'svn --version' when it is not
       expect(['health-check', 'svn --version']).toContain(result.command);
       
       if (result.success && result.data) {
@@ -74,7 +74,7 @@ describe('SVN MCP Integration Tests', () => {
     });
   });
 
-  // Solo ejecutar tests que requieren SVN si está disponible
+  // Only run tests that require SVN when it is available
   describe('SVN Commands (requires SVN installation)', () => {
     beforeAll(() => {
       if (!svnAvailable) {
@@ -90,10 +90,10 @@ describe('SVN MCP Integration Tests', () => {
 
       try {
         await svnService.getInfo();
-        // Si llegamos aquí, estamos en un working copy válido
+        // If we got here, we are inside a valid working copy
         expect(true).toBe(true);
       } catch (error: any) {
-        // Es esperado que falle si no estamos en un working copy
+        // It is expected to fail when we are not inside a working copy
         expect(error.message).toContain('Failed to get SVN info');
       }
     });
@@ -106,10 +106,10 @@ describe('SVN MCP Integration Tests', () => {
 
       try {
         await svnService.getStatus();
-        // Si llegamos aquí, estamos en un working copy válido
+        // If we got here, we are inside a valid working copy
         expect(true).toBe(true);
       } catch (error: any) {
-        // Es esperado que falle si no estamos en un working copy
+        // It is expected to fail when we are not inside a working copy
         expect(error.message).toContain('Failed to get SVN status');
       }
     });

--- a/tests/issue-3-remote-urls.test.ts
+++ b/tests/issue-3-remote-urls.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
-import { SvnService } from '../tools/svn-service';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { SvnService } from '../tools/svn-service.js';
 
-describe('Issue #3 - Error en svn_info con URLs remotas', () => {
+describe('Issue #3 - Error in svn_info with remote URLs', () => {
   let svnService: SvnService;
 
   beforeEach(() => {

--- a/tests/remote-command-errors.test.ts
+++ b/tests/remote-command-errors.test.ts
@@ -29,7 +29,7 @@ describe('Remote Command Error Handling', () => {
       
       // Check that errors contain more specific information
       const errorMessages = result.data.errors.join(' ');
-      expect(errorMessages).toContain('falló');
+      expect(errorMessages).toContain('failed');
       
       // Check that suggestions are provided
       expect(result.data.suggestions.length).toBeGreaterThan(0);
@@ -39,13 +39,13 @@ describe('Remote Command Error Handling', () => {
       const result = await svnService.diagnoseCommands();
       
       // Since SVN likely isn't installed in the test environment, we should get installation errors
-      const hasInstallationError = result.data.errors.some(error => 
-        error.includes('SVN no está instalado') || error.includes('no se encuentra en el PATH')
+      const hasInstallationError = result.data.errors.some(error =>
+        error.includes('SVN is not installed') || error.includes('not found in PATH')
       );
       expect(hasInstallationError).toBe(true);
-      
+
       const hasInstallationSuggestion = result.data.suggestions.some(suggestion =>
-        suggestion.includes('Instala SVN') || suggestion.includes('PATH')
+        suggestion.includes('Install SVN') || suggestion.includes('PATH')
       );
       expect(hasInstallationSuggestion).toBe(true);
     });
@@ -78,7 +78,7 @@ describe('Remote Command Error Handling', () => {
         expect(errorMessage.length).toBeGreaterThan(0);
         
         // Check if it's the enhanced SVN installation error
-        if (errorMessage.includes('SVN no está instalado')) {
+        if (errorMessage.includes('SVN is not installed')) {
           expect(errorMessage).toContain('PATH');
         }
       }
@@ -95,7 +95,7 @@ describe('Remote Command Error Handling', () => {
       
       // Each error should have corresponding details
       for (const error of result.data.errors) {
-        expect(error).toContain('falló');
+        expect(error).toContain('failed');
         expect(typeof error).toBe('string');
         expect(error.length).toBeGreaterThan(10);
       }

--- a/tests/svn-target-resolution.test.ts
+++ b/tests/svn-target-resolution.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  resolveSvnTarget,
+  combineRepoUrl,
+  parseListOutput
+} from '../common/utils.js';
+import { SvnError } from '../common/types.js';
+
+describe('SVN target resolution', () => {
+  const config = {
+    workingDirectory: '/tmp/wc',
+    url: 'https://svn.example.com/repo'
+  };
+
+  it('passes through full URLs unchanged', () => {
+    const url = 'https://other.host/project/trunk';
+    expect(resolveSvnTarget(url, config)).toEqual({ value: url, kind: 'url' });
+  });
+
+  it('joins repo-relative paths with SVN_URL', () => {
+    expect(resolveSvnTarget('/trunk/app.sql', config)).toEqual({
+      value: 'https://svn.example.com/repo/trunk/app.sql',
+      kind: 'url'
+    });
+  });
+
+  it('normalizes local paths when no URL prefix applies', () => {
+    const result = resolveSvnTarget('src/main.ts', config);
+    expect(result.kind).toBe('path');
+    expect(result.value).toContain('src');
+  });
+
+  it('rejects empty targets', () => {
+    expect(() => resolveSvnTarget('', config)).toThrow(SvnError);
+  });
+});
+
+describe('combineRepoUrl', () => {
+  it('strips duplicate slashes', () => {
+    expect(combineRepoUrl('https://svn.example.com/repo/', '/trunk/')).toBe(
+      'https://svn.example.com/repo/trunk'
+    );
+  });
+});
+
+describe('parseListOutput', () => {
+  it('parses simple listing lines', () => {
+    const output = 'README.md\ntrunk/\n';
+    expect(parseListOutput(output, false)).toEqual([
+      { name: 'README.md', kind: 'file' },
+      { name: 'trunk', kind: 'dir' }
+    ]);
+  });
+
+  it('parses verbose listing lines', () => {
+    const output = '   42 alice 1280 2024-01-15 10:00:00 +0000 README.md\n';
+    const entries = parseListOutput(output, true);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('README.md');
+    expect(entries[0].revision).toBe(42);
+    expect(entries[0].author).toBe('alice');
+    expect(entries[0].size).toBe(1280);
+  });
+});

--- a/tools/svn-service.ts
+++ b/tools/svn-service.ts
@@ -9,6 +9,9 @@ import {
   SvnCommitOptions,
   SvnAddOptions,
   SvnDeleteOptions,
+  SvnCatOptions,
+  SvnListOptions,
+  SvnListEntry,
   SvnError
 } from '../common/types.js';
 
@@ -18,11 +21,13 @@ import {
   parseInfoOutput,
   parseStatusOutput,
   parseLogOutput,
+  parseListOutput,
   validateSvnInstallation,
   isWorkingCopy,
   normalizePath,
   validatePath,
   validateSvnUrl,
+  resolveSvnTarget,
   cleanOutput,
   formatDuration,
   clearSvnCredentials
@@ -36,32 +41,32 @@ export class SvnService {
   }
 
   /**
-   * Función auxiliar para manejar errores comunes de SVN
+   * Helper function to handle common SVN errors
    */
   private handleSvnError(error: any, operation: string): never {
     let message = `Failed to ${operation}`;
-    
+
     if (error.message.includes('E155007') || error.message.includes('not a working copy')) {
-      message = `El directorio '${this.config.workingDirectory}' no es un working copy de SVN. Asegúrate de estar en un directorio que contenga un repositorio SVN o hacer checkout primero.`;
+      message = `'${this.config.workingDirectory}' is not an SVN working copy. Run checkout first or point SVN_WORKING_DIRECTORY at a valid checkout.`;
     } else if (error.message.includes('E175002') || error.message.includes('Unable to connect')) {
-      message = `No se puede conectar al repositorio SVN. Verifica tu conexión a internet y las credenciales.`;
+      message = `Cannot reach the SVN repository — check network access and credentials.`;
     } else if (error.message.includes('E170001') || error.message.includes('Authentication failed')) {
-      message = `Error de autenticación. Verifica tu nombre de usuario y contraseña SVN.`;
+      message = `SVN authentication failed — verify SVN_USERNAME and SVN_PASSWORD.`;
     } else if (error.message.includes('E155036') || error.message.includes('working copy locked')) {
-      message = `El working copy está bloqueado. Ejecuta 'svn cleanup' para resolverlo.`;
+      message = `The working copy is locked. Run 'svn cleanup' to resolve it.`;
     } else if (error.message.includes('E200030') || error.message.includes('sqlite')) {
-      message = `Error en la base de datos del working copy. Ejecuta 'svn cleanup' para repararlo.`;
+      message = `Working copy database error. Run 'svn cleanup' to repair it.`;
     } else if (error.stderr && error.stderr.length > 0) {
       message = `${message}: ${error.stderr}`;
     } else {
       message = `${message}: ${error.message}`;
     }
-    
+
     throw new SvnError(message);
   }
 
   /**
-   * Verificar que SVN está disponible y configurado correctamente
+   * Verify that SVN is available and correctly configured
    */
   async healthCheck(): Promise<SvnResponse<{
     svnAvailable: boolean;
@@ -70,7 +75,7 @@ export class SvnService {
     repositoryAccessible?: boolean;
   }>> {
     try {
-      // Verificar instalación de SVN
+      // Verify SVN installation
       const svnAvailable = await validateSvnInstallation(this.config);
       if (!svnAvailable) {
         return {
@@ -81,11 +86,11 @@ export class SvnService {
         };
       }
 
-      // Obtener versión de SVN
+      // Get SVN version
       const versionResponse = await executeSvnCommand(this.config, ['--version', '--quiet']);
       const version = versionResponse.data as string;
 
-      // Verificar si estamos en un working copy
+      // Check whether we are inside a working copy
       const workingCopyValid = await isWorkingCopy(this.config.workingDirectory!);
 
       let repositoryAccessible = false;
@@ -121,22 +126,13 @@ export class SvnService {
   }
 
   /**
-   * Obtener información del working copy o directorio específico
+   * Get information about the working copy or a specific directory
    */
   async getInfo(path?: string): Promise<SvnResponse<SvnInfo>> {
     try {
       const args = ['info'];
       if (path) {
-        // Check if it's a URL or a local path
-        if (validateSvnUrl(path)) {
-          // It's a URL, add it directly without normalization
-          args.push(path);
-        } else if (validatePath(path)) {
-          // It's a local path, normalize it
-          args.push(normalizePath(path));
-        } else {
-          throw new SvnError(`Invalid path or URL: ${path}`);
-        }
+        args.push(resolveSvnTarget(path, this.config).value);
       }
 
       const response = await executeSvnCommand(this.config, args);
@@ -156,7 +152,7 @@ export class SvnService {
   }
 
   /**
-   * Obtener estado de archivos en el working copy
+   * Get the status of files in the working copy
    */
   async getStatus(path?: string, showAll: boolean = false): Promise<SvnResponse<SvnStatus[]>> {
     try {
@@ -170,14 +166,14 @@ export class SvnService {
       }
 
       let response;
-      
-      // Si showAll es true, intentar primero con --show-updates
+
+      // If showAll is true, try first with --show-updates
       if (showAll) {
         try {
           const argsWithUpdates = [...args, '--show-updates'];
           response = await executeSvnCommand(this.config, argsWithUpdates);
         } catch (error: any) {
-          // Si falla con --show-updates, intentar sin él
+          // If --show-updates fails, fall back to local status only
           console.warn(`Warning: --show-updates failed, falling back to local status only: ${error.message}`);
           response = await executeSvnCommand(this.config, args);
         }
@@ -201,71 +197,65 @@ export class SvnService {
   }
 
   /**
-   * Obtener historial de cambios (log)
+   * Get change history (log)
    */
   async getLog(
-    path?: string, 
-    limit?: number, 
+    path?: string,
+    limit?: number,
     revision?: string
   ): Promise<SvnResponse<SvnLogEntry[]>> {
     try {
       const args = ['log'];
-      
+
       if (limit && limit > 0) {
         args.push('--limit', limit.toString());
       }
-      
+
       if (revision) {
         args.push('--revision', revision);
       }
-      
+
       if (path) {
-        if (!validatePath(path)) {
-          throw new SvnError(`Invalid path: ${path}`);
-        }
-        args.push(normalizePath(path));
+        args.push(resolveSvnTarget(path, this.config).value);
       }
 
       let response;
       try {
         response = await executeSvnCommand(this.config, args);
       } catch (error: any) {
-        // Detectar si SVN no está instalado
+        // Detect if SVN is not installed
         if ((error.message.includes('spawn') && error.message.includes('ENOENT')) ||
             error.code === 127) {
           const enhancedError = new SvnError(
-            'SVN no está instalado o no se encuentra en el PATH del sistema. Instala Subversion para usar este comando.'
+            'SVN is not installed or not found in the system PATH. Install Subversion to use this command.'
           );
           enhancedError.command = error.command;
           enhancedError.code = error.code;
           throw enhancedError;
         }
-        
-        // Detectar errores de red/conectividad y proporcionar mensajes más útiles
-        if (error.message.includes('E175002') || 
+
+        // Detect network/connectivity errors and surface more helpful messages
+        if (error.message.includes('E175002') ||
             error.message.includes('Unable to connect') ||
             error.message.includes('Connection refused') ||
             error.message.includes('Network is unreachable') ||
             error.code === 1) {
-          
-          // Intentar con opciones que funcionen sin conectividad remota si es posible
-          console.warn(`Log remoto falló, posible problema de conectividad: ${error.message}`);
-          
-          // Para comandos log, podemos intentar usar --offline si está disponible, 
-          // o proporcionar una respuesta vacía con información útil
+
+          console.warn(`Remote log failed, possible connectivity issue: ${error.message}`);
+
           const enhancedError = new SvnError(
-            `No se pudo obtener el historial de cambios. Posibles causas:
-            - Sin conectividad al servidor SVN
-            - Credenciales requeridas pero no proporcionadas
-            - Servidor SVN temporalmente inaccesible
-            - Working copy no sincronizado con el repositorio remoto`
+            `Could not retrieve change history. Possible causes:
+            - No connectivity to the SVN server
+            - Credentials required but not provided
+            - SVN server temporarily unreachable
+            - Working copy out of sync with the remote repository`
           );
           enhancedError.command = error.command;
           enhancedError.stderr = error.stderr;
           enhancedError.code = error.code;
           throw enhancedError;
         }
-        // Re-lanzar otros errores sin modificar
+        // Re-throw any other error unchanged
         throw error;
       }
 
@@ -285,7 +275,7 @@ export class SvnService {
   }
 
   /**
-   * Obtener diferencias entre versiones
+   * Get differences between revisions
    */
   async getDiff(
     path?: string,
@@ -294,20 +284,19 @@ export class SvnService {
   ): Promise<SvnResponse<string>> {
     try {
       const args = ['diff'];
-      
+      const resolved = path ? resolveSvnTarget(path, this.config).value : undefined;
+
       if (oldRevision && newRevision) {
-        args.push('--old', `${path || '.'}@${oldRevision}`);
-        args.push('--new', `${path || '.'}@${newRevision}`);
+        const base = resolved || '.';
+        args.push('--old', `${base}@${oldRevision}`);
+        args.push('--new', `${base}@${newRevision}`);
       } else if (oldRevision) {
         args.push('--revision', oldRevision);
-        if (path) {
-          args.push(normalizePath(path));
+        if (resolved) {
+          args.push(resolved);
         }
-      } else if (path) {
-        if (!validatePath(path)) {
-          throw new SvnError(`Invalid path: ${path}`);
-        }
-        args.push(normalizePath(path));
+      } else if (resolved) {
+        args.push(resolved);
       }
 
       const response = await executeSvnCommand(this.config, args);
@@ -326,7 +315,7 @@ export class SvnService {
   }
 
   /**
-   * Checkout de un repositorio
+   * Check out a repository
    */
   async checkout(
     url: string,
@@ -381,7 +370,7 @@ export class SvnService {
   }
 
   /**
-   * Actualizar working copy
+   * Update the working copy
    */
   async update(
     path?: string,
@@ -429,7 +418,7 @@ export class SvnService {
   }
 
   /**
-   * Añadir archivos al control de versiones
+   * Add files to version control
    */
   async add(
     paths: string | string[],
@@ -438,7 +427,7 @@ export class SvnService {
     try {
       const pathArray = Array.isArray(paths) ? paths : [paths];
       
-      // Validar todas las rutas
+      // Validate all paths
       for (const path of pathArray) {
         if (!validatePath(path)) {
           throw new SvnError(`Invalid path: ${path}`);
@@ -467,7 +456,7 @@ export class SvnService {
         args.push('--parents');
       }
 
-      // Añadir rutas normalizadas
+      // Append normalized paths
       args.push(...pathArray.map(p => normalizePath(p)));
 
       const response = await executeSvnCommand(this.config, args);
@@ -486,7 +475,7 @@ export class SvnService {
   }
 
   /**
-   * Confirmar cambios al repositorio
+   * Commit changes to the repository
    */
   async commit(
     options: SvnCommitOptions,
@@ -519,7 +508,7 @@ export class SvnService {
         args.push('--no-unlock');
       }
 
-      // Añadir rutas específicas si se proporcionan
+      // Append specific paths when provided
       if (paths && paths.length > 0) {
         for (const path of paths) {
           if (!validatePath(path)) {
@@ -547,7 +536,7 @@ export class SvnService {
   }
 
   /**
-   * Eliminar archivos del control de versiones
+   * Remove files from version control
    */
   async delete(
     paths: string | string[],
@@ -556,7 +545,7 @@ export class SvnService {
     try {
       const pathArray = Array.isArray(paths) ? paths : [paths];
       
-      // Validar todas las rutas
+      // Validate all paths
       for (const path of pathArray) {
         if (!validatePath(path)) {
           throw new SvnError(`Invalid path: ${path}`);
@@ -577,7 +566,7 @@ export class SvnService {
         args.push('--message', options.message);
       }
 
-      // Añadir rutas normalizadas
+      // Append normalized paths
       args.push(...pathArray.map(p => normalizePath(p)));
 
       const response = await executeSvnCommand(this.config, args);
@@ -596,13 +585,13 @@ export class SvnService {
   }
 
   /**
-   * Revertir cambios locales
+   * Revert local changes
    */
   async revert(paths: string | string[]): Promise<SvnResponse<string>> {
     try {
       const pathArray = Array.isArray(paths) ? paths : [paths];
       
-      // Validar todas las rutas
+      // Validate all paths
       for (const path of pathArray) {
         if (!validatePath(path)) {
           throw new SvnError(`Invalid path: ${path}`);
@@ -611,7 +600,7 @@ export class SvnService {
 
       const args = ['revert'];
       
-      // Añadir rutas normalizadas
+      // Append normalized paths
       args.push(...pathArray.map(p => normalizePath(p)));
 
       const response = await executeSvnCommand(this.config, args);
@@ -630,7 +619,7 @@ export class SvnService {
   }
 
   /**
-   * Limpiar working copy
+   * Clean up the working copy
    */
   async cleanup(path?: string): Promise<SvnResponse<string>> {
     try {
@@ -659,7 +648,7 @@ export class SvnService {
   }
 
   /**
-   * Diagnóstico específico para comandos problemáticos
+   * Targeted diagnostics for problematic commands
    */
   async diagnoseCommands(): Promise<SvnResponse<{
     statusLocal: boolean;
@@ -679,45 +668,45 @@ export class SvnService {
     };
 
     try {
-      // Probar svn status local
+      // Test local svn status
       try {
         await executeSvnCommand(this.config, ['status']);
         results.statusLocal = true;
       } catch (error: any) {
-        const errorMsg = this.categorizeError(error, 'status local');
+        const errorMsg = this.categorizeError(error, 'local status');
         results.errors.push(errorMsg.message);
         if (errorMsg.suggestion) {
           results.suggestions.push(errorMsg.suggestion);
         }
       }
 
-      // Probar svn status con --show-updates
+      // Test svn status with --show-updates
       try {
         await executeSvnCommand(this.config, ['status', '--show-updates']);
         results.statusRemote = true;
       } catch (error: any) {
-        const errorMsg = this.categorizeError(error, 'status remoto');
+        const errorMsg = this.categorizeError(error, 'remote status');
         results.errors.push(errorMsg.message);
         if (errorMsg.suggestion) {
           results.suggestions.push(errorMsg.suggestion);
         }
       }
 
-      // Probar svn log básico
+      // Test basic svn log
       try {
         await executeSvnCommand(this.config, ['log', '--limit', '1']);
         results.logBasic = true;
       } catch (error: any) {
-        const errorMsg = this.categorizeError(error, 'log básico');
+        const errorMsg = this.categorizeError(error, 'basic log');
         results.errors.push(errorMsg.message);
         if (errorMsg.suggestion) {
           results.suggestions.push(errorMsg.suggestion);
         }
       }
 
-      // Agregar sugerencias generales basadas en los resultados
+      // Add general suggestions based on the results
       if (!results.statusRemote && !results.logBasic && results.statusLocal) {
-        results.suggestions.push('Los comandos remotos fallan pero el local funciona. Revisa la conectividad de red y credenciales SVN.');
+        results.suggestions.push('Remote commands fail but the local one works. Review network connectivity and SVN credentials.');
       }
 
       return {
@@ -728,7 +717,7 @@ export class SvnService {
       };
 
     } catch (error: any) {
-      results.errors.push(`Error general: ${error.message}`);
+      results.errors.push(`General error: ${error.message}`);
       return {
         success: false,
         data: results,
@@ -740,78 +729,78 @@ export class SvnService {
   }
 
   /**
-   * Categorizar errores y proporcionar sugerencias específicas
+   * Categorize errors and provide specific suggestions
    */
   private categorizeError(error: any, commandType: string): { message: string; suggestion?: string } {
-    const baseMessage = `${commandType} falló`;
-    
-    // SVN no encontrado en el sistema
+    const baseMessage = `${commandType} failed`;
+
+    // SVN not found in the system
     if ((error.message.includes('spawn') && error.message.includes('ENOENT')) ||
         error.code === 127) {
       return {
-        message: `${baseMessage}: SVN no está instalado o no se encuentra en el PATH`,
-        suggestion: 'Instala SVN (subversion) o verifica que esté en el PATH del sistema'
+        message: `${baseMessage}: SVN is not installed or not found in PATH`,
+        suggestion: 'Install SVN (subversion) or make sure it is available in the system PATH'
       };
     }
-    
-    // Errores de conectividad
-    if (error.message.includes('E175002') || 
+
+    // Connectivity errors
+    if (error.message.includes('E175002') ||
         error.message.includes('Unable to connect') ||
         error.message.includes('Connection refused') ||
         error.message.includes('Network is unreachable')) {
       return {
-        message: `${baseMessage}: Sin conectividad al servidor SVN`,
-        suggestion: 'Verifica tu conexión a internet y que el servidor SVN esté accesible'
+        message: `${baseMessage}: No connectivity to the SVN server`,
+        suggestion: 'Check your internet connection and that the SVN server is reachable'
       };
     }
-    
-    // Errores de autenticación - demasiados intentos
-    if (error.message.includes('E215004') || 
+
+    // Authentication errors - too many attempts
+    if (error.message.includes('E215004') ||
         error.message.includes('No more credentials') ||
         error.message.includes('we tried too many times')) {
       return {
-        message: `${baseMessage}: Demasiados intentos de autenticación fallidos`,
-        suggestion: 'Las credenciales pueden estar incorrectas o cachadas. Limpia el cache de credenciales SVN y verifica SVN_USERNAME y SVN_PASSWORD'
+        message: `${baseMessage}: Too many failed authentication attempts`,
+        suggestion: 'Credentials may be incorrect or cached. Clear the SVN credentials cache and verify SVN_USERNAME and SVN_PASSWORD'
       };
     }
-    
-    // Errores de autenticación generales
-    if (error.message.includes('E170001') || 
+
+    // General authentication errors
+    if (error.message.includes('E170001') ||
         error.message.includes('Authentication failed') ||
         error.message.includes('authorization failed')) {
       return {
-        message: `${baseMessage}: Error de autenticación`,
-        suggestion: 'Verifica tus credenciales SVN (SVN_USERNAME y SVN_PASSWORD)'
+        message: `${baseMessage}: Authentication error`,
+        suggestion: 'Verify your SVN credentials (SVN_USERNAME and SVN_PASSWORD)'
       };
     }
-    
-    // Working copy no válido
-    if (error.message.includes('E155007') || 
+
+    // Invalid working copy
+    if (error.message.includes('E155007') ||
         error.message.includes('not a working copy')) {
       return {
-        message: `${baseMessage}: No es un working copy válido`,
-        suggestion: 'Asegúrate de estar en un directorio con checkout de SVN o ejecuta svn checkout primero'
+        message: `${baseMessage}: Not a valid working copy`,
+        suggestion: 'Make sure you are in an SVN checkout directory or run svn checkout first'
       };
     }
-    
-    // Working copy bloqueado
-    if (error.message.includes('E155036') || 
+
+    // Working copy locked
+    if (error.message.includes('E155036') ||
         error.message.includes('working copy locked')) {
       return {
-        message: `${baseMessage}: Working copy bloqueado`,
-        suggestion: 'Ejecuta "svn cleanup" para desbloquear el working copy'
+        message: `${baseMessage}: Working copy locked`,
+        suggestion: 'Run "svn cleanup" to unlock the working copy'
       };
     }
-    
-    // Error genérico con código 1 (frecuente en comandos remotos)
+
+    // Generic exit code 1 (common with remote commands)
     if (error.code === 1) {
       return {
-        message: `${baseMessage}: Comando falló con código 1 (posible problema de red/autenticación)`,
-        suggestion: 'Revisa conectividad de red, credenciales SVN, y que el repositorio sea accesible'
+        message: `${baseMessage}: Command failed with exit code 1 (possible network/authentication issue)`,
+        suggestion: 'Check network connectivity, SVN credentials, and that the repository is reachable'
       };
     }
-    
-    // Error genérico
+
+    // Fallback
     return {
       message: `${baseMessage}: ${error.message}`,
       suggestion: undefined
@@ -819,9 +808,92 @@ export class SvnService {
   }
 
   /**
-   * Limpiar cache de credenciales SVN para resolver errores de autenticación
+   * Clear the SVN credentials cache to resolve authentication errors
    */
   async clearCredentials(): Promise<SvnResponse> {
     return await clearSvnCredentials(this.config);
+  }
+
+  /**
+   * Show the contents of a versioned file (svn cat).
+   * Accepts a local path or a repository URL.
+   */
+  async cat(target: string, options: SvnCatOptions = {}): Promise<SvnResponse<string>> {
+    try {
+      if (!target || typeof target !== 'string') {
+        throw new SvnError('Target path or URL is required for svn cat');
+      }
+
+      const args = ['cat'];
+
+      if (options.revision !== undefined && options.revision !== null && options.revision !== '') {
+        args.push('--revision', String(options.revision));
+      }
+
+      args.push(resolveSvnTarget(target, this.config).value);
+
+      const response = await executeSvnCommand(this.config, args);
+
+      return {
+        success: true,
+        data: cleanOutput(response.data as string),
+        command: response.command,
+        workingDirectory: response.workingDirectory,
+        executionTime: response.executionTime
+      };
+
+    } catch (error: any) {
+      this.handleSvnError(error, 'get file contents (svn cat)');
+    }
+  }
+
+  /**
+   * List entries of a versioned directory (svn list).
+   * Accepts a local path or a repository URL. If no target is given, the working copy is used.
+   */
+  async list(
+    target?: string,
+    options: SvnListOptions = {}
+  ): Promise<SvnResponse<{ entries: SvnListEntry[]; raw: string }>> {
+    try {
+      const args = ['list'];
+
+      if (options.verbose) {
+        args.push('--verbose');
+      }
+
+      if (options.depth) {
+        args.push('--depth', options.depth);
+      } else if (options.recursive) {
+        args.push('--recursive');
+      }
+
+      if (options.includeExternals) {
+        args.push('--include-externals');
+      }
+
+      if (options.revision !== undefined && options.revision !== null && options.revision !== '') {
+        args.push('--revision', String(options.revision));
+      }
+
+      if (target) {
+        args.push(resolveSvnTarget(target, this.config).value);
+      }
+
+      const response = await executeSvnCommand(this.config, args);
+      const raw = cleanOutput(response.data as string);
+      const entries = parseListOutput(raw, !!options.verbose);
+
+      return {
+        success: true,
+        data: { entries, raw },
+        command: response.command,
+        workingDirectory: response.workingDirectory,
+        executionTime: response.executionTime
+      };
+
+    } catch (error: any) {
+      this.handleSvnError(error, 'list directory (svn list)');
+    }
   }
 } 


### PR DESCRIPTION
- Add svn_cat and svn_list MCP tools (with local path / repo URL support, revision selection, and verbose listing) including types, service methods, and a verbose-list parser.
- Translate all user-facing messages, errors, tool descriptions, and output strings from Spanish to English.
- Translate all code comments in source and tests to English.
- Translate README, TROUBLESHOOTING, SVN_MCP_IMPLEMENTATION, and SOLUCION_ERRORES docs, plus config.example.env and run-mcp scripts.
- Update assertions in auth-error and remote-command tests to match the new English error strings.